### PR TITLE
Feature Laser Module

### DIFF
--- a/webots_ros2_core/CHANGELOG.rst
+++ b/webots_ros2_core/CHANGELOG.rst
@@ -7,6 +7,7 @@ Changelog for package webots_ros2_core
 * Added support for multi robots.
 * Added a new tf_publisher node to publish tf of desired Webots nodes.
 * Added the possibility to run nodes in synchronized mode (using the 'synchronization' parameter).
+* Added a laser_publisher module.
 
 0.0.2 (2019-09-23)
 ------------------

--- a/webots_ros2_core/package.xml
+++ b/webots_ros2_core/package.xml
@@ -15,6 +15,7 @@
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>webots_ros2_msgs</exec_depend>
+  <exec_depend>python-transforms3d-pip</exec_depend>
 
   <!-- These test dependencies are optional
   Their purpose is to make sure that the code passes the linters -->

--- a/webots_ros2_core/webots_ros2_core/laser_publisher.py
+++ b/webots_ros2_core/webots_ros2_core/laser_publisher.py
@@ -102,7 +102,6 @@ class LaserPublisher():
             transformStamped.header.stamp = Time(sec=nextSec, nanosec=nextNanosec)
             transformStamped.header.frame_id = self.prefix + lidar.getName()
             transformStamped.child_frame_id = name
-            # transformStamped.transform.translation.x = 0.5
             q1 = transforms3d.quaternions.axangle2quat([0, 1, 0], -1.5708)
             q2 = transforms3d.quaternions.axangle2quat([1, 0, 0], 1.5708)
             result = transforms3d.quaternions.qmult(q1, q2)

--- a/webots_ros2_core/webots_ros2_core/laser_publisher.py
+++ b/webots_ros2_core/webots_ros2_core/laser_publisher.py
@@ -99,7 +99,7 @@ class LaserPublisher():
             msg.ranges.resize(lidar.getHorizontalResolution())  # TODO: check if Python valid
             # msg.intensities.resize(lidar->getHorizontalResolution());
 
-            lidarValues = lidar.getLayerRangeImage(0)  # TODO: multiple layers
+            lidarValues = lidar.getLayerRangeImage(i)
             for i in range(lidar.getHorizontalResolution()):
                 msg.ranges[i] = lidarValues[i]
             if lidar.getNumberOfLayers() > 1:

--- a/webots_ros2_core/webots_ros2_core/laser_publisher.py
+++ b/webots_ros2_core/webots_ros2_core/laser_publisher.py
@@ -35,7 +35,7 @@ except Exception as e:
 
 
 class LaserPublisher():
-    """Publish as ROS topics the lidar laser scan."""
+    """Publish as ROS topics the laser scans of the lidars."""
 
     def __init__(self, robot, node, prefix='', parameters={}):
         """

--- a/webots_ros2_core/webots_ros2_core/laser_publisher.py
+++ b/webots_ros2_core/webots_ros2_core/laser_publisher.py
@@ -65,9 +65,11 @@ class LaserPublisher():
                         self.publishers[device] = {}
                         name = prefix + device.getName() + '_' + str(i)
                         topicName = prefix + topicName + '_' + str(i)
-                        self.publishers[device][name] = self.node.create_publisher(LaserScan, topicName, 1)
+                        self.publishers[device][name] = self.node.create_publisher(LaserScan,
+                                                                                   topicName, 1)
                 else:
-                    self.publishers[device] = self.node.create_publisher(LaserScan, prefix + topicName, 1)
+                    self.publishers[device] = self.node.create_publisher(LaserScan,
+                                                                         prefix + topicName, 1)
                 self.lastUpdate[device] = -100
         self.jointStateTimer = self.create_timer(0.001 * self.timestep, self.callback)
 

--- a/webots_ros2_core/webots_ros2_core/laser_publisher.py
+++ b/webots_ros2_core/webots_ros2_core/laser_publisher.py
@@ -84,7 +84,7 @@ class LaserPublisher():
         for lidar in self.lidars:
             if self.robot.getTime() - self.lastUpdate[lidar] >= lidar.getSamplingPeriod():
                 self.publish(lidar, tFMessage.transforms)
-        if len(tFMessage.transforms) > 0:
+        if tFMessage.transforms:
             self.tfPublisher.publish(tFMessage)
 
     def publish(self, lidar, transforms):

--- a/webots_ros2_core/webots_ros2_core/laser_publisher.py
+++ b/webots_ros2_core/webots_ros2_core/laser_publisher.py
@@ -89,8 +89,8 @@ class LaserPublisher():
                 msg.header.frame_id = self.prefix + lidar.getName() + '_' + str(i)
             else:
                 msg.header.frame_id = self.prefix + lidar.getName()
-            msg.angle_min = 0.0
-            msg.angle_max = lidar.getFov()
+            msg.angle_min = -0.5 * lidar.getFov()
+            msg.angle_max = 0.5 * lidar.getFov()
             msg.angle_increment = lidar.getFov() / (lidar.getHorizontalResolution() - 1)
             msg.scan_time = lidar.getSamplingPeriod() / 1000.0
             msg.range_min = lidar.getMinRange()

--- a/webots_ros2_core/webots_ros2_core/laser_publisher.py
+++ b/webots_ros2_core/webots_ros2_core/laser_publisher.py
@@ -33,14 +33,14 @@ class LaserPublisher():
     """Publish as ROS topics the lidar laser scan."""
 
     def __init__(self, robot, node, prefix='', parameters={}):
-        """Initialize the lidars and the topic.
+        """
+        Initialize the lidars and the topic.
 
         Arguments:
         prefix: prefix for the topic names
         parameters: customization parameters dictionnary the key are the device names
                     the value are dictionaries with the following key:
                         'timestep' and 'topic name'
-
         """
         self.robot = robot
         self.node = node
@@ -74,7 +74,7 @@ class LaserPublisher():
         self.jointStateTimer = self.create_timer(0.001 * self.timestep, self.callback)
 
     def callback(self):
-        """This callback is called every 1ms to check if a laser scan should be pulibshed."""
+        """Callback called every 1ms to check if a laser scan should be pulibshed."""
         for lidar in self.lidars:
             if self.robot.getTime() - self.lastUpdate[lidar] >= lidar.getSamplingPeriod():
                 self.publish(lidar)

--- a/webots_ros2_core/webots_ros2_core/laser_publisher.py
+++ b/webots_ros2_core/webots_ros2_core/laser_publisher.py
@@ -71,10 +71,9 @@ class LaserPublisher():
                     self.publishers[device] = self.node.create_publisher(LaserScan,
                                                                          prefix + topicName, 1)
                 self.lastUpdate[device] = -100
-        self.jointStateTimer = self.create_timer(0.001 * self.timestep, self.callback)
+        self.jointStateTimer = self.node.create_timer(0.001 * self.timestep, self.callback)
 
     def callback(self):
-        """Callback called every 1ms to check if a laser scan should be pulibshed."""
         for lidar in self.lidars:
             if self.robot.getTime() - self.lastUpdate[lidar] >= lidar.getSamplingPeriod():
                 self.publish(lidar)
@@ -96,12 +95,10 @@ class LaserPublisher():
             msg.scan_time = lidar.getSamplingPeriod() / 1000.0
             msg.range_min = lidar.getMinRange()
             msg.range_max = lidar.getMaxRange()
-            msg.ranges.resize(lidar.getHorizontalResolution())  # TODO: check if Python valid
-            # msg.intensities.resize(lidar->getHorizontalResolution());
 
             lidarValues = lidar.getLayerRangeImage(i)
             for i in range(lidar.getHorizontalResolution()):
-                msg.ranges[i] = lidarValues[i]
+                msg.ranges.append(lidarValues[i])
             if lidar.getNumberOfLayers() > 1:
                 self.publishers[lidar][msg.header.frame_id].publish(msg)
             else:

--- a/webots_ros2_core/webots_ros2_core/laser_publisher.py
+++ b/webots_ros2_core/webots_ros2_core/laser_publisher.py
@@ -24,7 +24,7 @@ from builtin_interfaces.msg import Time
 from geometry_msgs.msg import TransformStamped
 
 
-import transforms3d  # TODO: add in dependencies
+import transforms3d
 
 try:
     append_webots_python_lib_to_path()

--- a/webots_ros2_core/webots_ros2_core/laser_publisher.py
+++ b/webots_ros2_core/webots_ros2_core/laser_publisher.py
@@ -32,7 +32,7 @@ except Exception as e:
 class LaserPublisher():
     """Publish as ROS topics the lidar laser scan."""
 
-    def __init__(self, robot, node, prefix='', parameters):
+    def __init__(self, robot, node, prefix='', parameters={}):
         """Initialize the lidars and the topic.
 
         Arguments:

--- a/webots_ros2_core/webots_ros2_core/laser_publisher.py
+++ b/webots_ros2_core/webots_ros2_core/laser_publisher.py
@@ -39,7 +39,7 @@ class LaserPublisher():
 
     def __init__(self, robot, node, prefix='', parameters={}):
         """
-        Initialize the lidars and the topic.
+        Initialize the lidars and the topics.
 
         Arguments:
         prefix: prefix for the topic names

--- a/webots_ros2_core/webots_ros2_core/laser_publisher.py
+++ b/webots_ros2_core/webots_ros2_core/laser_publisher.py
@@ -32,7 +32,7 @@ except Exception as e:
 class LaserPublisher():
     """Publish as ROS topics the lidar laser scan."""
 
-    def __init__(self, robot, node, prefix=''):
+    def __init__(self, robot, node, prefix='', parameters):
         """Initialize the lidars and the topic."""
         self.robot = robot
         self.node = node
@@ -45,7 +45,10 @@ class LaserPublisher():
             device = robot.getDeviceByIndex(i)
             if device.getNodeType() == Node.LIDAR:
                 self.lidars.append(device)
-                device.enable(self.timestep)  # TODO: variable time step
+                if device.getName() in parameters and 'timestep' in parameters[device.getName()]:
+                    device.enable(parameters[device.getName()][timestep])
+                else:
+                    device.enable(self.timestep)
                 if device.getNumberOfLayers() > 1:
                     for i in range(device.getNumberOfLayers()):
                         self.publishers[device] = {}

--- a/webots_ros2_core/webots_ros2_core/laser_publisher.py
+++ b/webots_ros2_core/webots_ros2_core/laser_publisher.py
@@ -1,0 +1,76 @@
+# Copyright 1996-2019 Cyberbotics Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Laser publisher."""
+
+import sys
+
+from webots_ros2_core.utils import append_webots_python_lib_to_path
+
+from sensor_msgs.msg import LaserScan
+from builtin_interfaces.msg import Time
+
+try:
+    append_webots_python_lib_to_path()
+    from controller import Node
+except Exception as e:
+    sys.stderr.write('"WEBOTS_HOME" is not correctly set.')
+    raise e
+
+
+class LaserPublisher():
+    """Publish as ROS topics the lidar laser scan."""
+
+    def __init__(self, robot, node, prefix=''):
+        """Initialize the position sensors and the topic."""
+        self.robot = robot
+        self.node = node
+        self.lidars = []
+        self.publishers = {}
+        self.lastUpdate = {}
+        self.timestep = int(robot.getBasicTimeStep())
+        for i in range(robot.getNumberOfDevices()):
+            device = robot.getDeviceByIndex(i)
+            if device.getNodeType() == Node.LIDAR:
+                self.lidars.append(device)
+                device.enable(self.timestep)  # TODO: variable time step
+                self.publishers[device] = self.node.create_publisher(LaserScan, prefix + device.getName(), 1)  # TODO: variable names
+                self.lastUpdate[device] = -100
+        self.jointStateTimer = self.create_timer(0.001 * self.timestep, self.callback)
+
+    def callback(self):
+        for lidar in self.lidars:
+            if self.robot.getTime() - self.lastUpdate[lidar] >= lidar.getSamplingPeriod():
+                self.publish(lidar)
+
+    def publish(self, lidar):
+        """Publish the 'joint_states' topic with up to date value."""
+        seconds = int(self.robot.getTime())
+        nanoseconds = int((self.robot.getTime() - seconds) * 1.0e+6)
+        msg = LaserScan()
+        msg.header.stamp = Time(sec=seconds, nanosec=nanoseconds)
+        msg.header.frame_id = 'From simulation state data'
+        msg.angle_min = 0.0
+        msg.angle_max = lidar.getFov()
+        msg.angle_increment = lidar.getFov() / (lidar.getHorizontalResolution() - 1)
+        msg.scan_time = lidar.getSamplingPeriod() / 1000.0
+        msg.range_min = lidar.getMinRange()
+        msg.range_max = lidar.getMaxRange()
+        msg.ranges.resize(lidar.getHorizontalResolution())  # TODO: check if Python valid
+        # msg.intensities.resize(lidar->getHorizontalResolution());
+
+        lidarValues = lidar.getLayerRangeImage(0)  # TODO: multiple layers
+        for i in range(lidar.getHorizontalResolution()):
+            msg.ranges[i] = lidarValues[i]
+        self.publishers[lidar].publish(msg)

--- a/webots_ros2_core/webots_ros2_core/laser_publisher.py
+++ b/webots_ros2_core/webots_ros2_core/laser_publisher.py
@@ -24,7 +24,7 @@ from builtin_interfaces.msg import Time
 from geometry_msgs.msg import TransformStamped
 
 
-import transforms3d  #TODO: add in dependencies
+import transforms3d  # TODO: add in dependencies
 
 try:
     append_webots_python_lib_to_path()
@@ -68,11 +68,11 @@ class LaserPublisher():
                     topicName = parameters[topicName]['topic name']
                 if device.getNumberOfLayers() > 1:
                     self.publishers[device] = {}
-                    for i in range(device.getNumberOfLayers()):
-                        name = prefix + device.getName() + '_' + str(i)
-                        indexedTopicName = prefix + topicName + '_' + str(i)
-                        self.publishers[device][name] = self.node.create_publisher(LaserScan,
-                                                                                   indexedTopicName, 1)
+                    for j in range(device.getNumberOfLayers()):
+                        name = prefix + device.getName() + '_' + str(j)
+                        indexedTopicName = prefix + topicName + '_' + str(j)
+                        publisher = self.node.create_publisher(LaserScan, indexedTopicName, 1)
+                        self.publishers[device][name] = publisher
                 else:
                     self.publishers[device] = self.node.create_publisher(LaserScan,
                                                                          prefix + topicName, 1)


### PR DESCRIPTION
This PR adds a laser module that allows the user to publish the lidar values as laser-scan.
This module is made generic so it will work with any lidar node, but the arguments of the constructor allow the user to customize it (e.g. for specific update frequencies or topic names).