### PR TITLE
Remove ROS Crystal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ services:
   - docker
 env:
   matrix:
-    - ROS_DISTRO="crystal" DOCKER_RUN_OPTS='-e TRAVIS'
-    - ROS_DISTRO="crystal" DOCKER_RUN_OPTS='-e TRAVIS' ROS_REPO=testing
     - ROS_DISTRO="dashing" DOCKER_RUN_OPTS='-e TRAVIS'
     - ROS_DISTRO="dashing" DOCKER_RUN_OPTS='-e TRAVIS' ROS_REPO=testing
     - ROS_DISTRO="eloquent" DOCKER_RUN_OPTS='-e TRAVIS'


### PR DESCRIPTION
As ROS crystal is not supported anymore (end of life December 2019) and often causing the python API is not compatible with Dashing and Eloquent I think we can skip this distribution from now.