### PR TITLE
Extend webots_ros2_examples

### DIFF
--- a/webots_ros2_examples/CHANGELOG.rst
+++ b/webots_ros2_examples/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package webots_ros2_examples
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+1.0.0 (2020-XX-YY)
+------------------
+* Added a new subscriber method to motor node to set motor velocity.
+
 0.0.2 (2019-09-23)
 ------------------
 * Initial version

--- a/webots_ros2_examples/package.xml
+++ b/webots_ros2_examples/package.xml
@@ -13,6 +13,7 @@
 
   <exec_depend>rclpy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
+  <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>webots_ros2_msgs</exec_depend>

--- a/webots_ros2_examples/webots_ros2_examples/example_controller.py
+++ b/webots_ros2_examples/webots_ros2_examples/example_controller.py
@@ -20,7 +20,6 @@ from webots_ros2_msgs.srv import SetDifferentialWheelSpeed
 import rclpy
 
 from std_msgs.msg import Float64
-from geometry_msgs.msg import Vector3
 from geometry_msgs.msg import Twist
 
 
@@ -28,7 +27,8 @@ class ExampleController(WebotsNode):
 
     def __init__(self, args):
         super().__init__('example_controller', args)
-        self.sensorTimer = self.create_timer(0.001 * self.timestep, self.sensor_callback)
+        self.sensorTimer = self.create_timer(0.001 * self.timestep,
+                                             self.sensor_callback)
         self.leftMotor = self.robot.getMotor('motor.left')
         self.rightMotor = self.robot.getMotor('motor.right')
         self.leftMotor.setPosition(float('inf'))
@@ -36,12 +36,15 @@ class ExampleController(WebotsNode):
         self.leftMotor.setVelocity(0)
         self.rightMotor.setVelocity(0)
         self.motorMaxSpeed = self.leftMotor.getMaxVelocity()
-        self.motorService = self.create_service(SetDifferentialWheelSpeed, 'motor', self.motor_callback)
+        self.motorService = self.create_service(SetDifferentialWheelSpeed,
+                                                'motor', self.motor_callback)
         self.sensorPublisher = self.create_publisher(Float64, 'sensor', 10)
         # front central proximity sensor
         self.frontSensor = self.robot.getDistanceSensor('prox.horizontal.2')
         self.frontSensor.enable(self.timestep)
-        self.cmdVelSubscriber = self.create_subscription(Twist , 'motor', self.cmdVel_callback, 10)
+        self.cmdVelSubscriber = self.create_subscription(Twist, 'motor',
+                                                         self.cmdVel_callback,
+                                                         10)
 
     def sensor_callback(self):
         # Publish distance sensor value
@@ -55,14 +58,20 @@ class ExampleController(WebotsNode):
         return response
 
     def cmdVel_callback(self, msg):
-        wheel_gap = 0.1 # in meter
-        wheel_radius = 0.021 # in meter
-        leftSpeed  = (2.0 * msg.linear.x - msg.angular.z * wheel_gap) / (2.0 * wheel_radius)
-        rightSpeed = (2.0 * msg.linear.x + msg.angular.z * wheel_gap) / (2.0 * wheel_radius)
-        if leftSpeed >  self.motorMaxSpeed: leftSpeed =  self.motorMaxSpeed
-        if leftSpeed < -self.motorMaxSpeed: leftSpeed = -self.motorMaxSpeed
-        if rightSpeed >  self.motorMaxSpeed: rightSpeed =  self.motorMaxSpeed
-        if rightSpeed < -self.motorMaxSpeed: rightSpeed = -self.motorMaxSpeed
+        wheel_gap = 0.1  # in meter
+        wheel_radius = 0.021  # in meter
+        leftSpeed = (2.0 * msg.linear.x - msg.angular.z * wheel_gap) / (
+                     2.0 * wheel_radius)
+        rightSpeed = (2.0 * msg.linear.x + msg.angular.z * wheel_gap) / (
+                      2.0 * wheel_radius)
+        if leftSpeed > self.motorMaxSpeed:
+            leftSpeed = self.motorMaxSpeed
+        if leftSpeed < -self.motorMaxSpeed:
+            leftSpeed = -self.motorMaxSpeed
+        if rightSpeed > self.motorMaxSpeed:
+            rightSpeed = self.motorMaxSpeed
+        if rightSpeed < -self.motorMaxSpeed:
+            rightSpeed = -self.motorMaxSpeed
         self.leftMotor.setVelocity(leftSpeed)
         self.rightMotor.setVelocity(rightSpeed)
 

--- a/webots_ros2_examples/webots_ros2_examples/example_controller.py
+++ b/webots_ros2_examples/webots_ros2_examples/example_controller.py
@@ -36,30 +36,12 @@ class ExampleController(WebotsNode):
         self.leftMotor.setVelocity(0)
         self.rightMotor.setVelocity(0)
         self.motorMaxSpeed = self.leftMotor.getMaxVelocity()
-        self.get_logger().info('max_vel: %f' % self.motorMaxSpeed)
         self.motorService = self.create_service(SetDifferentialWheelSpeed, 'motor', self.motor_callback)
         self.sensorPublisher = self.create_publisher(Float64, 'sensor', 10)
         # front central proximity sensor
         self.frontSensor = self.robot.getDistanceSensor('prox.horizontal.2')
         self.frontSensor.enable(self.timestep)
-
         self.cmdVelSubscriber = self.create_subscription(Twist , 'motor', self.cmdVel_callback, 10)
-
-    def cmdVel_callback(self, msg):
-        wheel_gap = 0.1    # in meter
-        wheel_radius = 0.021 # in meter
-        self.get_logger().info('lin_vel: %f' % msg.linear.x)
-        self.get_logger().info('ang_vel: %f' % msg.angular.z)
-        leftSpeed  = (2.0 * msg.linear.x - msg.angular.z * wheel_gap) / (2.0 * wheel_radius)
-        rightSpeed = (2.0 * msg.linear.x + msg.angular.z * wheel_gap) / (2.0 * wheel_radius)
-        self.get_logger().info('leftSpeed : %f' % leftSpeed)
-        self.get_logger().info('rightSpeed: %f' % rightSpeed)
-        if leftSpeed >  self.motorMaxSpeed: leftSpeed =  self.motorMaxSpeed
-        if leftSpeed < -self.motorMaxSpeed: leftSpeed = -self.motorMaxSpeed
-        if rightSpeed >  self.motorMaxSpeed: rightSpeed =  self.motorMaxSpeed
-        if rightSpeed < -self.motorMaxSpeed: rightSpeed = -self.motorMaxSpeed
-        self.leftMotor.setVelocity(leftSpeed)
-        self.rightMotor.setVelocity(rightSpeed)
 
     def sensor_callback(self):
         # Publish distance sensor value
@@ -72,28 +54,25 @@ class ExampleController(WebotsNode):
         self.rightMotor.setVelocity(request.right_speed)
         return response
 
-
-#class CommandVelocitySubscriber(Node):
-#    def __init__(self):
-#        super().__init__('command_velocity_subscriber')
-#        self.subscription = self.create_subscription(Twist, 'motor', self.cmdVel_callback, 10)
-#        self.subscription  # prevent unused variable warning
-#
-#    def cmdVel_callback(self, msg):
-#        self.get_logger().info('lin_vel: %f' % msg.linear.x*100)
-#        self.get_logger().info('ang_vel: %f' % msg.angular.z*100)
+    def cmdVel_callback(self, msg):
+        wheel_gap = 0.1 # in meter
+        wheel_radius = 0.021 # in meter
+        leftSpeed  = (2.0 * msg.linear.x - msg.angular.z * wheel_gap) / (2.0 * wheel_radius)
+        rightSpeed = (2.0 * msg.linear.x + msg.angular.z * wheel_gap) / (2.0 * wheel_radius)
+        if leftSpeed >  self.motorMaxSpeed: leftSpeed =  self.motorMaxSpeed
+        if leftSpeed < -self.motorMaxSpeed: leftSpeed = -self.motorMaxSpeed
+        if rightSpeed >  self.motorMaxSpeed: rightSpeed =  self.motorMaxSpeed
+        if rightSpeed < -self.motorMaxSpeed: rightSpeed = -self.motorMaxSpeed
+        self.leftMotor.setVelocity(leftSpeed)
+        self.rightMotor.setVelocity(rightSpeed)
 
 
 def main(args=None):
     rclpy.init(args=args)
 
     exampleController = ExampleController(args=args)
-    #command_velocity_subscriber = CommandVelocitySubscriber()
 
     rclpy.spin(exampleController)
-    #rclpy.spin(command_velocity_subscriber)
-
-    #command_velocity_subscriber.destroy_node()
     rclpy.shutdown()
 
 

--- a/webots_ros2_examples/webots_ros2_examples/example_controller.py
+++ b/webots_ros2_examples/webots_ros2_examples/example_controller.py
@@ -20,6 +20,8 @@ from webots_ros2_msgs.srv import SetDifferentialWheelSpeed
 import rclpy
 
 from std_msgs.msg import Float64
+from geometry_msgs.msg import Vector3
+from geometry_msgs.msg import Twist
 
 
 class ExampleController(WebotsNode):
@@ -33,12 +35,31 @@ class ExampleController(WebotsNode):
         self.rightMotor.setPosition(float('inf'))
         self.leftMotor.setVelocity(0)
         self.rightMotor.setVelocity(0)
-        self.motorService = self.create_service(SetDifferentialWheelSpeed, 'motor',
-                                                self.motor_callback)
+        self.motorMaxSpeed = self.leftMotor.getMaxVelocity()
+        self.get_logger().info('max_vel: %f' % self.motorMaxSpeed)
+        self.motorService = self.create_service(SetDifferentialWheelSpeed, 'motor', self.motor_callback)
         self.sensorPublisher = self.create_publisher(Float64, 'sensor', 10)
         # front central proximity sensor
         self.frontSensor = self.robot.getDistanceSensor('prox.horizontal.2')
         self.frontSensor.enable(self.timestep)
+
+        self.cmdVelSubscriber = self.create_subscription(Twist , 'motor', self.cmdVel_callback, 10)
+
+    def cmdVel_callback(self, msg):
+        wheel_gap = 0.1    # in meter
+        wheel_radius = 0.021 # in meter
+        self.get_logger().info('lin_vel: %f' % msg.linear.x)
+        self.get_logger().info('ang_vel: %f' % msg.angular.z)
+        leftSpeed  = (2.0 * msg.linear.x - msg.angular.z * wheel_gap) / (2.0 * wheel_radius)
+        rightSpeed = (2.0 * msg.linear.x + msg.angular.z * wheel_gap) / (2.0 * wheel_radius)
+        self.get_logger().info('leftSpeed : %f' % leftSpeed)
+        self.get_logger().info('rightSpeed: %f' % rightSpeed)
+        if leftSpeed >  self.motorMaxSpeed: leftSpeed =  self.motorMaxSpeed
+        if leftSpeed < -self.motorMaxSpeed: leftSpeed = -self.motorMaxSpeed
+        if rightSpeed >  self.motorMaxSpeed: rightSpeed =  self.motorMaxSpeed
+        if rightSpeed < -self.motorMaxSpeed: rightSpeed = -self.motorMaxSpeed
+        self.leftMotor.setVelocity(leftSpeed)
+        self.rightMotor.setVelocity(rightSpeed)
 
     def sensor_callback(self):
         # Publish distance sensor value
@@ -52,12 +73,27 @@ class ExampleController(WebotsNode):
         return response
 
 
+#class CommandVelocitySubscriber(Node):
+#    def __init__(self):
+#        super().__init__('command_velocity_subscriber')
+#        self.subscription = self.create_subscription(Twist, 'motor', self.cmdVel_callback, 10)
+#        self.subscription  # prevent unused variable warning
+#
+#    def cmdVel_callback(self, msg):
+#        self.get_logger().info('lin_vel: %f' % msg.linear.x*100)
+#        self.get_logger().info('ang_vel: %f' % msg.angular.z*100)
+
+
 def main(args=None):
     rclpy.init(args=args)
 
     exampleController = ExampleController(args=args)
+    #command_velocity_subscriber = CommandVelocitySubscriber()
 
     rclpy.spin(exampleController)
+    #rclpy.spin(command_velocity_subscriber)
+
+    #command_velocity_subscriber.destroy_node()
     rclpy.shutdown()
 
 

--- a/webots_ros2_examples/webots_ros2_examples/example_controller.py
+++ b/webots_ros2_examples/webots_ros2_examples/example_controller.py
@@ -60,10 +60,10 @@ class ExampleController(WebotsNode):
     def cmdVel_callback(self, msg):
         wheel_gap = 0.1  # in meter
         wheel_radius = 0.021  # in meter
-        leftSpeed = (2.0 * msg.linear.x - msg.angular.z * wheel_gap) / (
-                     2.0 * wheel_radius)
-        rightSpeed = (2.0 * msg.linear.x + msg.angular.z * wheel_gap) / (
-                      2.0 * wheel_radius)
+        leftSpeed = ((2.0 * msg.linear.x - msg.angular.z * wheel_gap) /
+                     (2.0 * wheel_radius))
+        rightSpeed = ((2.0 * msg.linear.x + msg.angular.z * wheel_gap) /
+                      (2.0 * wheel_radius))
         if leftSpeed > self.motorMaxSpeed:
             leftSpeed = self.motorMaxSpeed
         if leftSpeed < -self.motorMaxSpeed:

--- a/webots_ros2_examples/webots_ros2_examples/example_controller.py
+++ b/webots_ros2_examples/webots_ros2_examples/example_controller.py
@@ -58,20 +58,16 @@ class ExampleController(WebotsNode):
         return response
 
     def cmdVel_callback(self, msg):
-        wheel_gap = 0.1  # in meter
-        wheel_radius = 0.021  # in meter
-        leftSpeed = ((2.0 * msg.linear.x - msg.angular.z * wheel_gap) /
-                     (2.0 * wheel_radius))
-        rightSpeed = ((2.0 * msg.linear.x + msg.angular.z * wheel_gap) /
-                      (2.0 * wheel_radius))
-        if leftSpeed > self.motorMaxSpeed:
-            leftSpeed = self.motorMaxSpeed
-        if leftSpeed < -self.motorMaxSpeed:
-            leftSpeed = -self.motorMaxSpeed
-        if rightSpeed > self.motorMaxSpeed:
-            rightSpeed = self.motorMaxSpeed
-        if rightSpeed < -self.motorMaxSpeed:
-            rightSpeed = -self.motorMaxSpeed
+        wheelGap = 0.1  # in meter
+        wheelRadius = 0.021  # in meter
+        leftSpeed = ((2.0 * msg.linear.x - msg.angular.z * wheelGap) /
+                     (2.0 * wheelRadius))
+        rightSpeed = ((2.0 * msg.linear.x + msg.angular.z * wheelGap) /
+                      (2.0 * wheelRadius))
+        leftSpeed = min(self.motorMaxSpeed, max(-self.motorMaxSpeed,
+                                                leftSpeed))
+        rightSpeed = min(self.motorMaxSpeed, max(-self.motorMaxSpeed,
+                                                 rightSpeed))
         self.leftMotor.setVelocity(leftSpeed)
         self.rightMotor.setVelocity(rightSpeed)
 


### PR DESCRIPTION
**Description**
Extend `webots_ros2_examples` with a new method to set motor velocity. Instead of using a client/service, now it can be used with a subscriber/publisher.

**Affected Packages**
List of affected packages:
  - `webots_ros2_examples`
