### PR TITLE
Improve Support for Differential Drive Calibration

### DIFF
--- a/webots_ros2_epuck/README.md
+++ b/webots_ros2_epuck/README.md
@@ -216,7 +216,7 @@ ros2 run webots_ros2_epuck drive_calibrator --ros-args -p type:=linear
 ```
 if the robot overshoots the given distance (default 0.1335m) we should increase the wheel radius, otherwise decrease it:
 ```
-ros2 param set /epuck_driver wheel_radius 0.021
+ros2 param set /epuck_driver wheel_radius 0.0215
 ```
 
 Second, to calibrate the distance between the wheel we can let the robot rotate in the spot:

--- a/webots_ros2_epuck/README.md
+++ b/webots_ros2_epuck/README.md
@@ -56,22 +56,27 @@ $ ros2 topic list -t
 
 ### Infra-red, Light Sensors, and LEDs
 ![e-puck2 camera and infrared sensors](https://raw.githubusercontent.com/cyberbotics/webots/master/docs/guide/images/robots/epuck/sensors_and_leds.png)  
-E-puck2 has 8 infra-red sensors (named as `ps0-7`) all of which are mapped to the same name ROS2 topics of type [sensor_msgs/Range](https://github.com/ros2/common_interfaces/blob/master/sensor_msgs/msg/Range.msg). Therefore, you can obtain a distance from a sensor as follows:
+E-puck2 has 8 infra-red sensors (named as `ps0-7`) all of which are mapped to the same name ROS2 topics of type [sensor_msgs/Range](https://github.com/ros2/common_interfaces/blob/master/sensor_msgs/msg/Range.msg).
+Therefore, you can obtain a distance from a sensor as follows:
 ``` 
 ros2 topic echo /ps1
 ```
-Besides infrared sensors, e-puck2 is upgraded with long-range ToF sensor positioned just above the camera. Data from this sensor is also exposed through the [sensor_msgs/Range](https://github.com/ros2/common_interfaces/blob/master/sensor_msgs/msg/Range.msg) topic with name `tof`.
+Besides infrared sensors, e-puck2 is upgraded with long-range ToF sensor positioned just above the camera.
+Data from this sensor is also exposed through the [sensor_msgs/Range](https://github.com/ros2/common_interfaces/blob/master/sensor_msgs/msg/Range.msg) topic with name `tof`.
 
-All distance sensors are combined to create [sensor_msgs/LaserScan](https://github.com/ros2/common_interfaces/blob/master/sensor_msgs/msg/LaserScan.msg) so you can use it directly in SLAM packages. You can test it as:
+All distance sensors are combined to create [sensor_msgs/LaserScan](https://github.com/ros2/common_interfaces/blob/master/sensor_msgs/msg/LaserScan.msg) so you can use it directly in SLAM packages.You can test it as:
 ```
 ros2 topic echo /scan
 ```
 
-The same infra-red sensors act as light sensors. In the ROS2 driver, data from the sensors is published as [sensor_msgs/Illuminance](https://github.com/ros2/common_interfaces/blob/master/sensor_msgs/msg/Illuminance.msg) message (unit is lux) and you can subscribe to it as follows:
+The same infra-red sensors act as light sensors.
+In the ROS2 driver, data from the sensors is published as [sensor_msgs/Illuminance](https://github.com/ros2/common_interfaces/blob/master/sensor_msgs/msg/Illuminance.msg) message (unit is lux) and you can subscribe to it as follows:
 ``` 
 ros2 topic echo /ls1
 ```
-Notice in the image above, there are 8 LEDs as well-positioned around the robot. LEDs `led0`, `led2`, `led4` and `led6` can be only turned on or off, while LEDs `led1`, `led3`, `led5` and `led7` have controllable RGB components. Therefore, in the case of binary LEDs, you can test them as:
+Notice in the image above, there are 8 LEDs as well-positioned around the robot.
+LEDs `led0`, `led2`, `led4` and `led6` can be only turned on or off, while LEDs `led1`, `led3`, `led5` and `led7` have controllable RGB components.
+Therefore, in the case of binary LEDs, you can test them as:
 ``` 
 ros2 topic pub /led0 std_msgs/Bool '{ "data": true }'
 ```
@@ -79,7 +84,7 @@ and RGB as:
 ```
 ros2 topic pub /led1 std_msgs/Int32 '{ "data": 0xFF0000 }'
 ```
-where 3 lower bytes of Int32 represent 3 bytes of R, G and B components. 
+where 3 lower bytes of Int32 represent 3 bytes of R, G and B components.
 
 ### Velocity Control
 Standard [geometry_msgs/Twist](https://github.com/ros2/common_interfaces/blob/master/geometry_msgs/msg/Twist.msg) topic with name `/cmd_vel` is exposed for velocity control.
@@ -96,7 +101,8 @@ angular:
 > Note that only `linear.x` and `angular.z` are considered as e-puck2 is differential wheeled robot.
 
 ### Odometry
-Standard ROS2 messages [nav_msgs/Odometry](https://github.com/ros2/common_interfaces/blob/master/nav_msgs/msg/Odometry.msg) are used to publish odometry data. You can subscribe to it with:
+Standard ROS2 messages [nav_msgs/Odometry](https://github.com/ros2/common_interfaces/blob/master/nav_msgs/msg/Odometry.msg) are used to publish odometry data
+You can subscribe to it with:
 ``` 
 ros2 topic echo /odom
 ```
@@ -105,7 +111,8 @@ In case you are not interested in covariance matrices, you can use `--no-arr` pa
 ros2 topic echo --no-arr /odom
 ```
 
-> Note that ROS uses [REP](https://www.ros.org/reps/rep-0103.html) convention (x-forward, y-left and z-up) while Webots inherited convention from [VRML](https://en.wikipedia.org/wiki/VRML) (x-right, y-up, z-backward). Therefore, you will see translations in Webots as following <img src ="https://render.githubusercontent.com/render/math?math=x_{Webots} = -y_{ROS}" />, <img src ="https://render.githubusercontent.com/render/math?math=y_{Webots} = z_{ROS}" /> and <img src ="https://render.githubusercontent.com/render/math?math=z_{Webots} = -x_{ROS}" />.
+> Note that ROS uses [REP](https://www.ros.org/reps/rep-0103.html) convention (x-forward, y-left and z-up) while Webots inherited convention from [VRML](https://en.wikipedia.org/wiki/VRML) (x-right, y-up, z-backward).
+> Therefore, you will see translations in Webots as following <img src ="https://render.githubusercontent.com/render/math?math=x_{Webots} = -y_{ROS}" />, <img src ="https://render.githubusercontent.com/render/math?math=y_{Webots} = z_{ROS}" /> and <img src ="https://render.githubusercontent.com/render/math?math=z_{Webots} = -x_{ROS}" />.
 
 You can also visualise odometry in `rviz` :
 
@@ -114,18 +121,23 @@ ros2 launch webots_ros2_epuck example.launch.py rviz:=true
 ```
 
 ### Camera
-Camera data and details are described through `image_raw` (type [sensor_msgs/Image](https://github.com/ros2/common_interfaces/blob/master/sensor_msgs/msg/Image.msg)) and `camera_info` (type [sensor_msgs/CameraInfo](https://github.com/ros2/common_interfaces/blob/master/sensor_msgs/msg/CameraInfo.msg)) topics. Compared to the physical robot driver there is no [sensor_msgs/CompressedImage](https://github.com/ros2/common_interfaces/blob/master/sensor_msgs/msg/CompressedImage.msg) since the images are not meant to be transfer thourgh a network. 
+Camera data and details are described through `image_raw` (type [sensor_msgs/Image](https://github.com/ros2/common_interfaces/blob/master/sensor_msgs/msg/Image.msg)) and `camera_info` (type [sensor_msgs/CameraInfo](https://github.com/ros2/common_interfaces/blob/master/sensor_msgs/msg/CameraInfo.msg)) topics.
+Compared to the physical robot driver there is no [sensor_msgs/CompressedImage](https://github.com/ros2/common_interfaces/blob/master/sensor_msgs/msg/CompressedImage.msg) since the images are not meant to be transfer thourgh a network.
 
-You can run `rqt` , navigate to `Plugins > Visualization > Image View` and for topic choose `/image_raw`. Note that the image encoding is BGRA.
+You can run `rqt` , navigate to `Plugins > Visualization > Image View` and for topic choose `/image_raw`.
+Note that the image encoding is BGRA.
 
 ### IMU
-There are 3D accelerometer and 3D gyro hardware on e-puck2. You can access to this data through `imu` topic (type [sensor_msgs/Imu](https://github.com/ros2/common_interfaces/blob/master/sensor_msgs/msg/Imu.msg)), e.g.:
+There are 3D accelerometer and 3D gyro hardware on e-puck2.
+You can access to this data through `imu` topic (type [sensor_msgs/Imu](https://github.com/ros2/common_interfaces/blob/master/sensor_msgs/msg/Imu.msg)), e.g.:
 ```
 ros2 topic echo --no-arr /imu
 ```
 
 ### Ground Sensors
-Ground sensors come as an [optional module](http://www.e-puck.org/index.php?option=com_content&view=article&id=17&Itemid=18) for e-puck2. If the module is present, the ROS2 driver will automatically detect it and publish data. You can test them as:
+Ground sensors come as an [optional module](http://www.e-puck.org/index.php?option=com_content&view=article&id=17&Itemid=18) for e-puck2.
+If the module is present, the ROS2 driver will automatically detect it and publish data.
+You can test them as:
 ``` 
 ros2 topic echo /gs1
 ```
@@ -153,7 +165,8 @@ ros2 run tf2_ros tf2_echo odom map
 
 
 ### Navigation
-ROS2 Navigation2 stack (see [this figure](https://raw.githubusercontent.com/ros-planning/navigation2/eloquent-devel/doc/architecture/navigation_overview.png)) allows us to move robot from point A to point B by creating a global plan and avoiding local obstacles. It is integrated into e-puck example and you can run it by including `nav` parameter:
+ROS2 Navigation2 stack (see [this figure](https://raw.githubusercontent.com/ros-planning/navigation2/eloquent-devel/doc/architecture/navigation_overview.png)) allows us to move robot from point A to point B by creating a global plan and avoiding local obstacles.
+It is integrated into e-puck example and you can run it by including `nav` parameter:
 
 ```
 ros2 launch webots_ros2_epuck example_launch.py rviz:=true nav:=true mapper:=true fill_map:=false
@@ -188,7 +201,9 @@ This example will work properly only for [ROS2 Foxy](https://index.ros.org/doc/r
 
 
 ### Mapping
-Unfortunately, default SLAM implementation doesn't work well with e-puck. Therefore, we created a simple mapping node that relies purely on odometry. You can launch it as a part of the e-puck example launch file by adding `mapper` parameter:
+Unfortunately, default SLAM implementation doesn't work well with e-puck.
+Therefore, we created a simple mapping node that relies purely on odometry.
+You can launch it as a part of the e-puck example launch file by adding `mapper` parameter:
 ```
 ros2 launch webots_ros2_epuck example_launch.py rviz:=true mapper:=true
 ```
@@ -232,4 +247,5 @@ ros2 param set /epuck_driver wheel_distance 0.0514
 
 Third, repeat those two steps until you are satisfied with the precision.
 
-Note that you can measure distance by a tool (e.g. ruler), it is a good initial guess, but with the technique described above, you will achieve much better results. According to the paper, such techniques can significantly reduce systematic errors (page 4 and 23).
+Note that you can measure distance by a tool (e.g. ruler), it is a good initial guess, but with the technique described above, you will achieve much better results.
+According to the paper, such techniques can significantly reduce systematic errors (page 4 and 23).

--- a/webots_ros2_epuck/README.md
+++ b/webots_ros2_epuck/README.md
@@ -64,7 +64,8 @@ ros2 topic echo /ps1
 Besides infrared sensors, e-puck2 is upgraded with long-range ToF sensor positioned just above the camera.
 Data from this sensor is also exposed through the [sensor_msgs/Range](https://github.com/ros2/common_interfaces/blob/master/sensor_msgs/msg/Range.msg) topic with name `tof`.
 
-All distance sensors are combined to create [sensor_msgs/LaserScan](https://github.com/ros2/common_interfaces/blob/master/sensor_msgs/msg/LaserScan.msg) so you can use it directly in SLAM packages.You can test it as:
+All distance sensors are combined to create [sensor_msgs/LaserScan](https://github.com/ros2/common_interfaces/blob/master/sensor_msgs/msg/LaserScan.msg) so you can use it directly in SLAM packages.
+You can test it as:
 ```
 ros2 topic echo /scan
 ```

--- a/webots_ros2_epuck/README.md
+++ b/webots_ros2_epuck/README.md
@@ -214,7 +214,7 @@ First, we want to measure wheel radius and we can achieve it by letting the robo
 ```
 ros2 run webots_ros2_epuck drive_calibrator --ros-args -p type:=linear
 ```
-if the robot overshoots the given distance (default 0.1335m) we should decrease the wheel radius, otherwise increase it:
+if the robot overshoots the given distance (default 0.1335m) we should increase the wheel radius, otherwise decrease it:
 ```
 ros2 param set /epuck_driver wheel_radius 0.021
 ```
@@ -225,7 +225,7 @@ ros2 run webots_ros2_epuck drive_calibrator --ros-args -p type:=angular
 ```
 if overshoots the given number of rotations (default 4) then decrease the distance between the wheels, otherwise increase it.
 ```
-ros2 param set /epuck_driver wheel_distance 0.0515
+ros2 param set /epuck_driver wheel_distance 0.0514
 ```
 
 Third, repeat those two steps until you are satisfied with the precision.

--- a/webots_ros2_epuck/README.md
+++ b/webots_ros2_epuck/README.md
@@ -206,3 +206,28 @@ t2$ ros2 service call /map_server/change_state lifecycle_msgs/ChangeState "{tran
 t2$ ros2 service call /map_server/change_state lifecycle_msgs/ChangeState "{transition: {id: 3}}"
 t2$ ros2 launch webots_ros2_epuck example_launch.py rviz:=true nav:=true
 ```
+
+### Differential Drive Calibration
+Based on the rotation speed of each wheel and two constants, distance between the wheels and wheel radius, we can calculate the position of the robot in the local frame. Therefore. the precision of the position estimation depends a lot on the distance between the wheels and wheel radius. Those constants can vary from robot to robot and here we provide a tool to help you to calibrate it (this technique is very similar to one proposed in [_"Measurement and Correction of Systematic Odometry Errors in Mobile Robots"_](http://www-personal.umich.edu/~johannb/Papers/paper58.pdf)).  
+
+First, we want to measure wheel radius and we can achieve it by letting the robot move in a straight line:
+```
+ros2 run webots_ros2_epuck drive_calibrator --ros-args -p type:=linear
+```
+if the robot overshoots the given distance (default 0.1335m) we should decrease the wheel radius, otherwise increase it:
+```
+ros2 param set /epuck_driver wheel_radius 0.021
+```
+
+Second, to calibrate the distance between the wheel we can let the robot rotate in the spot:
+```
+ros2 run webots_ros2_epuck drive_calibrator --ros-args -p type:=angular
+```
+if overshoots the given number of rotations (default 4) then decrease the distance between the wheels, otherwise increase it.
+```
+ros2 param set /epuck_driver wheel_distance 0.0515
+```
+
+Third, repeat those two steps until you are satisfied with the precision.
+
+Note that you can measure distance by a tool (e.g. ruler), it is a good initial guess, but with the technique described above, you will achieve much better results. According to the paper, such techniques can significantly reduce systematic errors (page 4 and 23).

--- a/webots_ros2_epuck/webots_ros2_epuck/drive_calibrator.py
+++ b/webots_ros2_epuck/webots_ros2_epuck/drive_calibrator.py
@@ -94,14 +94,14 @@ class EPuckDriveCalibrator(Node):
             n_rotations = (self.odom_angular_last_abs - self.odom_angular_start)/(2*pi)
             if n_rotations > NUMBER_OF_ROTATIONS:
                 self.finish_calibration()
-            self.get_logger().info(f'Number of rotations: {n_rotations:.2f}')
+            self.get_logger().info(f'Number of rotations: {n_rotations:.4f}')
 
         # Linear calibration
         if self.type.value == 'linear':
             self.get_logger().info('Linear calibration in progress...')
             self.set_velocity(LINEAR_VELOCITY, 0)
             passed_distance = msg.pose.pose.position.x - self.odom_linear_start
-            self.get_logger().info(f'Passed distance: {passed_distance:.2f}')
+            self.get_logger().info(f'Passed distance: {passed_distance:.4f}')
             if passed_distance > self.distance.value:
                 self.finish_calibration()
 

--- a/webots_ros2_epuck/webots_ros2_epuck/drive_calibrator.py
+++ b/webots_ros2_epuck/webots_ros2_epuck/drive_calibrator.py
@@ -15,61 +15,40 @@
 # This node helps you to calibrate wheel radius and distance between the wheels
 # by moving the robot forward and correcting wheel radius, and rotating robot and
 # correcting distance between the wheels.
-# ros2 run webots_ros2_epuck drive_calibrator --ros-args -p type:=linear -p wheel_radius:=0.021
 
+from math import pi
 import rclpy
 from nav_msgs.msg import Odometry
 from rclpy.node import Node
-from rcl_interfaces.srv import SetParameters
-from rcl_interfaces.msg._parameter import Parameter
-from rclpy.parameter import ParameterType, ParameterValue
 from geometry_msgs.msg import Twist
 from webots_ros2_core.math_utils import quaternion_to_euler
 
 
-# Target distance for robot to pass in meters
 DEFAULT_DISTANCE = 0.1335
-# Default separation between two wheels (from e-puck website)
-DEFAULT_WHEEL_DISTANCE = 0.0552
-# Default wheel radius (from e-puck website)
-DEFAULT_WHEEL_RADIUS = 0.021
+NUMBER_OF_ROTATIONS = 4
+LINEAR_VELOCITY = 0.02
+ANGULAR_VELOCITY = 1
 
 
 class EPuckDriveCalibrator(Node):
-    def __init__(self, name, args=None):
+    def __init__(self, name):
         super().__init__(name)
-
-        self.test_done = False
-        self.rotation_count = 0
-        self.last_yaw = 0
 
         # Parameters
         self.type = self.declare_parameter('type', 'rotation')
         self.distance = self.declare_parameter('distance', DEFAULT_DISTANCE)
-        self.wheel_distance = self.declare_parameter(
-            'wheel_distance', DEFAULT_WHEEL_DISTANCE)
-        self.wheel_radius = self.declare_parameter(
-            'wheel_radius', DEFAULT_WHEEL_RADIUS)
 
         # Topics
         self.create_subscription(Odometry, '/odom', self.odometry_callback, 1)
         self.pub = self.create_publisher(Twist, '/cmd_vel', 10)
 
-        # Parameter service
-        self.cli = self.create_client(SetParameters, 'epuck/set_parameters')
-        self.cli.wait_for_service(timeout_sec=1.0)
-        self.set_param('wheel_distance', self.wheel_distance.value)
-        self.set_param('wheel_radius', self.wheel_radius.value)
-        self.get_logger().info('Setting wheel distance to: {}m'.format(self.wheel_distance.value))
-        self.get_logger().info('Setting wheel radius to: {}m'.format(self.wheel_radius.value))
-
-    def set_param(self, name, value):
-        req = SetParameters.Request()
-        param_value = ParameterValue(
-            double_value=value, type=ParameterType.PARAMETER_DOUBLE)
-        param = Parameter(name=name, value=param_value)
-        req.parameters.append(param)
-        self.cli.call_async(req)
+        # Odometry
+        self.odom_angular_last = 0.0
+        self.odom_angular_last_abs = 0.0
+        self.odom_linear_last = 0.0
+        self.odom_angular_start = 0.0
+        self.odom_linear_start = 0.0
+        self.odom_params_initialised = False
 
     def send_stop(self):
         self.test_done = True
@@ -82,52 +61,62 @@ class EPuckDriveCalibrator(Node):
         msg.linear.z = 0.0
         self.pub.publish(msg)
 
+    def set_velocity(self, linear, angular):
+        msg = Twist()
+        msg.angular.x = 0.0
+        msg.angular.y = 0.0
+        msg.angular.z = float(angular)
+        msg.linear.x = float(linear)
+        msg.linear.y = 0.0
+        msg.linear.z = 0.0
+        self.pub.publish(msg)
+
     def odometry_callback(self, msg: Odometry):
-        if not self.test_done and self.type.value == 'rotation':
-            # Send velocity
-            self.get_logger().info('Rotation calibration in progress...')
-            msg_twist = Twist()
-            msg_twist.angular.x = 0.0
-            msg_twist.angular.y = 0.0
-            msg_twist.angular.z = 1.0
-            msg_twist.linear.x = 0.0
-            msg_twist.linear.y = 0.0
-            msg_twist.linear.z = 0.0
-            self.pub.publish(msg_twist)
+        yaw, _, _ = quaternion_to_euler(msg.pose.pose.orientation)
+        if not self.odom_params_initialised:
+            if yaw < 0:
+                yaw = 2 * pi + yaw
+            self.odom_params_initialised = True
+            self.odom_angular_last = yaw
+            self.odom_angular_start = yaw
+            self.odom_angular_last_abs = yaw
+            self.odom_linear_last = msg.pose.pose.position.x
+            self.odom_linear_start = msg.pose.pose.position.x
+            return
 
-            # Receive data
-            yaw, _, _ = quaternion_to_euler(msg.pose.pose.orientation)
-            if yaw > 0 and self.last_yaw < 0:
-                self.rotation_count += 1
-            if self.rotation_count == 4:
+        # Resolve singularities (first for positive angle and then for negative angle)
+        if yaw - self.odom_angular_last > pi:
+            self.odom_angular_last_abs += 2*pi - (yaw - self.odom_angular_last)
+        elif self.odom_angular_last - yaw > pi:
+            self.odom_angular_last_abs += 2*pi - (self.odom_angular_last - yaw)
+        else:
+            self.odom_angular_last_abs += yaw - self.odom_angular_last
+
+        # Angular calibration
+        if self.type.value == 'angular':
+            self.get_logger().info('Angular calibration in progress...')
+            self.set_velocity(0, ANGULAR_VELOCITY)
+            n_rotations = (self.odom_angular_last_abs - self.odom_angular_start)/(2*pi)
+            if n_rotations > NUMBER_OF_ROTATIONS:
                 self.send_stop()
-            self.last_yaw = yaw
+            self.get_logger().info(f'Number of rotations: {n_rotations:.2f}')
 
-            self.get_logger().info('Circle: {}; Current angle: {}'.format(
-                self.rotation_count, yaw))
-
-        if not self.test_done and self.type.value == 'linear':
-            # Send velocity
-            self.get_logger().info('Rotation calibration in progress...')
-            msg_twist = Twist()
-            msg_twist.angular.x = 0.0
-            msg_twist.angular.y = 0.0
-            msg_twist.angular.z = 0.0
-            msg_twist.linear.x = 0.02
-            msg_twist.linear.y = 0.0
-            msg_twist.linear.z = 0.0
-            self.pub.publish(msg_twist)
-
-            # Receive data
-            print('X', msg.pose.pose.position.x)
-            if msg.pose.pose.position.x > self.distance.value:
+        # Linear calibration
+        if self.type.value == 'linear':
+            self.get_logger().info('Linear calibration in progress...')
+            self.set_velocity(LINEAR_VELOCITY, 0)
+            passed_distance = msg.pose.pose.position.x - self.odom_linear_start
+            self.get_logger().info(f'Passed distance: {passed_distance:.2f}')
+            if passed_distance > self.distance.value:
                 self.send_stop()
+
+        # Save readings
+        self.odom_angular_last = yaw
 
 
 def main(args=None):
     rclpy.init(args=args)
-    epuck_controller = EPuckDriveCalibrator(
-        'epuck_drive_calibrator', args=args)
+    epuck_controller = EPuckDriveCalibrator('epuck_drive_calibrator')
     rclpy.spin(epuck_controller)
     epuck_controller.destroy_node()
     rclpy.shutdown()


### PR DESCRIPTION
**Description**
This PR improves support for differential drive calibration (similar to [this](http://www-personal.umich.edu/~johannb/Papers/paper58.pdf)) to better estimate distance between the wheels and wheel radius.

**Affected Packages**
  - webots_ros2_epuck

**Tasks**
  - [x] Resolve angle singularities received from odometry (we want number of rotations)
  - [x] Incorporate initial readings from odometry
  - [x] Document the calibration process
  - [x] Verify the calibration process

**Additional context**
The initial idea was to fully automate the calibration process (branch `feature-auto-diffdrive-calib`) by using the ToF sensor for determining the number of rotations (landmark created based on two sequential readings) and passed distance:
https://github.com/cyberbotics/webots_ros2/blob/feature-auto-diffdrive-calib/webots_ros2_epuck/webots_ros2_epuck/drive_calibrator.py
Although the process worked in the simulation, detecting landmarks is not possible with the physical robot (FoV is too wide, fixed in https://github.com/cyberbotics/webots/pull/1577). 

I am not sure what to do with the branch, I would not like to delete it. In general, it is a good approach and I may recycle for something else in the future. Maybe I could fork it to my personal profile and delete the branch (`feature-auto-diffdrive-calib`)?
