### PR TITLE
Replace .now() method

### DIFF
--- a/webots_ros2_core/test/test_flake8.py
+++ b/webots_ros2_core/test/test_flake8.py
@@ -21,5 +21,5 @@ import pytest
 @pytest.mark.flake8
 @pytest.mark.linter
 def test_flake8():
-    rc = main(argv=[])
+    rc = main(argv=['--linelength', '128'])
     assert rc == 0, 'Found errors'

--- a/webots_ros2_core/webots_ros2_core/joint_state_publisher.py
+++ b/webots_ros2_core/webots_ros2_core/joint_state_publisher.py
@@ -19,7 +19,7 @@ import sys
 from webots_ros2_core.utils import append_webots_python_lib_to_path
 
 from sensor_msgs.msg import JointState
-from builtin_interfaces.msg import Time
+from rclpy.time import Time
 
 try:
     append_webots_python_lib_to_path()
@@ -57,10 +57,8 @@ class JointStatePublisher():
 
     def publish(self):
         """Publish the 'joint_states' topic with up to date value."""
-        seconds = int(self.robot.getTime())
-        nanoseconds = int((self.robot.getTime() - seconds) * 1.0e+6)
         msg = JointState()
-        msg.header.stamp = Time(sec=seconds, nanosec=nanoseconds)
+        msg.header.stamp = Time(seconds=self.robot.getTime()).to_msg()
         msg.header.frame_id = 'From simulation state data'
         msg.name = [s + self.jointPrefix for s in self.jointNames]
         msg.position = []

--- a/webots_ros2_core/webots_ros2_core/laser_publisher.py
+++ b/webots_ros2_core/webots_ros2_core/laser_publisher.py
@@ -20,7 +20,7 @@ from webots_ros2_core.utils import append_webots_python_lib_to_path
 
 from tf2_msgs.msg import TFMessage
 from sensor_msgs.msg import LaserScan
-from builtin_interfaces.msg import Time
+from rclpy.time import Time
 from geometry_msgs.msg import TransformStamped
 
 
@@ -89,17 +89,15 @@ class LaserPublisher():
 
     def publish(self, lidar, transforms):
         """Publish the laser scan topics with up to date value."""
-        nextTime = self.robot.getTime() + 0.001 * self.timestep
-        nextSec = int(nextTime)
-        # rounding prevents precision issues that can cause problems with ROS timers
-        nextNanosec = int(round(1000 * (nextTime - nextSec)) * 1.0e+6)
+
+        stamp = Time(seconds=self.robot.getTime() + 0.001 * self.timestep).to_msg()
         for i in range(lidar.getNumberOfLayers()):
             name = self.prefix + lidar.getName() + '_scan'
             if lidar.getNumberOfLayers() > 1:
                 name += '_' + str(i)
             # publish the lidar to scan transform
             transformStamped = TransformStamped()
-            transformStamped.header.stamp = Time(sec=nextSec, nanosec=nextNanosec)
+            transformStamped.header.stamp = stamp
             transformStamped.header.frame_id = self.prefix + lidar.getName()
             transformStamped.child_frame_id = name
             q1 = transforms3d.quaternions.axangle2quat([0, 1, 0], -1.5708)
@@ -117,7 +115,7 @@ class LaserPublisher():
             transforms.append(transformStamped)
             # publish the actual laser scan
             msg = LaserScan()
-            msg.header.stamp = Time(sec=self.node.sec, nanosec=self.node.nanosec)
+            msg.header.stamp = stamp
             msg.header.frame_id = name
             msg.angle_min = -0.5 * lidar.getFov()
             msg.angle_max = 0.5 * lidar.getFov()

--- a/webots_ros2_core/webots_ros2_core/laser_publisher.py
+++ b/webots_ros2_core/webots_ros2_core/laser_publisher.py
@@ -89,7 +89,6 @@ class LaserPublisher():
 
     def publish(self, lidar, transforms):
         """Publish the laser scan topics with up to date value."""
-
         stamp = Time(seconds=self.robot.getTime() + 0.001 * self.timestep).to_msg()
         for i in range(lidar.getNumberOfLayers()):
             name = self.prefix + lidar.getName() + '_scan'

--- a/webots_ros2_core/webots_ros2_core/tf_publisher.py
+++ b/webots_ros2_core/webots_ros2_core/tf_publisher.py
@@ -21,7 +21,7 @@ from webots_ros2_core.webots_node import WebotsNode
 
 from tf2_msgs.msg import TFMessage
 from geometry_msgs.msg import TransformStamped
-from builtin_interfaces.msg import Time
+from rclpy.time import Time
 
 
 class TfPublisher(WebotsNode):
@@ -42,16 +42,13 @@ class TfPublisher(WebotsNode):
     def tf_publisher_callback(self):
         # Publish TF for the next step
         # we use one step in advance to make sure no sensor data are published before
+        stamp = Time(seconds=self.robot.getTime() + 0.001 * self.timestep).to_msg()
         tFMessage = TFMessage()
-        nextTime = self.robot.getTime() + 0.001 * self.timestep
-        nextSec = int(nextTime)
-        # rounding prevents precision issues that can cause problems with ROS timers
-        nextNanosec = int(round(1000 * (nextTime - nextSec)) * 1.0e+6)
         for name in self.nodes:
             position = self.nodes[name].getPosition()
             orientation = self.nodes[name].getOrientation()
             transformStamped = TransformStamped()
-            transformStamped.header.stamp = (self.get_clock().now() + Dura).to_msg()
+            transformStamped.header.stamp = stamp
             transformStamped.header.frame_id = 'map'
             transformStamped.child_frame_id = name
             transformStamped.transform.translation.x = position[0]

--- a/webots_ros2_core/webots_ros2_core/tf_publisher.py
+++ b/webots_ros2_core/webots_ros2_core/tf_publisher.py
@@ -51,7 +51,7 @@ class TfPublisher(WebotsNode):
             position = self.nodes[name].getPosition()
             orientation = self.nodes[name].getOrientation()
             transformStamped = TransformStamped()
-            transformStamped.header.stamp = Time(sec=nextSec, nanosec=nextNanosec)
+            transformStamped.header.stamp = (self.get_clock().now() + Dura).to_msg()
             transformStamped.header.frame_id = 'map'
             transformStamped.child_frame_id = name
             transformStamped.transform.translation.x = position[0]

--- a/webots_ros2_core/webots_ros2_core/webots_node.py
+++ b/webots_ros2_core/webots_ros2_core/webots_node.py
@@ -28,7 +28,6 @@ from rosgraph_msgs.msg import Clock
 
 from rclpy.node import Node
 from rclpy.parameter import Parameter
-from builtin_interfaces.msg import Time
 
 try:
     append_webots_python_lib_to_path()

--- a/webots_ros2_core/webots_ros2_core/webots_node.py
+++ b/webots_ros2_core/webots_ros2_core/webots_node.py
@@ -86,9 +86,3 @@ class WebotsNode(Node):
         self.step(request.value)
         response.success = True
         return response
-
-    def now(self):
-        sim_time = self.robot.getTime()
-        seconds = int(sim_time)
-        nanoseconds = int((sim_time - seconds) * 1.0e+6)
-        return Time(sec=seconds, nanosec=nanoseconds)

--- a/webots_ros2_demos/webots_ros2_demos/follow_joint_trajectory_client.py
+++ b/webots_ros2_demos/webots_ros2_demos/follow_joint_trajectory_client.py
@@ -17,6 +17,7 @@
 from action_msgs.msg import GoalStatus
 from control_msgs.action import FollowJointTrajectory
 from trajectory_msgs.msg import JointTrajectoryPoint
+from builtin_interfaces.msg import Duration
 
 import rclpy
 from rclpy.action import ActionClient
@@ -71,7 +72,10 @@ class followJointTrajectoryClient(Node):
             trajectoryPoint = JointTrajectoryPoint(positions=point['positions'],
                                                    velocities=point['velocities'],
                                                    accelerations=point['accelerations'],
-                                                   time_from_start=point['time_from_start'])
+                                                   time_from_start=Duration(
+                                                       sec=point['time_from_start']['sec'],
+                                                       nanosec=point['time_from_start']['nanosec']
+                                                    ))
             goal_msg.trajectory.points.append(trajectoryPoint)
 
         self.get_logger().info('Sending goal request...')

--- a/webots_ros2_demos/webots_ros2_demos/follow_joint_trajectory_client.py
+++ b/webots_ros2_demos/webots_ros2_demos/follow_joint_trajectory_client.py
@@ -17,7 +17,6 @@
 from action_msgs.msg import GoalStatus
 from control_msgs.action import FollowJointTrajectory
 from trajectory_msgs.msg import JointTrajectoryPoint
-from builtin_interfaces.msg import Duration
 
 import rclpy
 from rclpy.action import ActionClient
@@ -69,12 +68,10 @@ class followJointTrajectoryClient(Node):
         goal_msg = FollowJointTrajectory.Goal()
         goal_msg.trajectory.joint_names = trajectory['joint_names']
         for point in trajectory['points']:
-            duration = Duration(sec=int(point['time_from_start']['sec']),
-                                nanosec=int(int(point['time_from_start']['nanosec']) * 1.0e+6))
             trajectoryPoint = JointTrajectoryPoint(positions=point['positions'],
                                                    velocities=point['velocities'],
                                                    accelerations=point['accelerations'],
-                                                   time_from_start=duration)
+                                                   time_from_start=point['time_from_start'])
             goal_msg.trajectory.points.append(trajectoryPoint)
 
         self.get_logger().info('Sending goal request...')

--- a/webots_ros2_epuck/webots_ros2_epuck/driver.py
+++ b/webots_ros2_epuck/webots_ros2_epuck/driver.py
@@ -119,7 +119,7 @@ class EPuckDriver(WebotsDifferentialDriveNode):
                 self.ground_sensor_publishers[idx] = self.create_publisher(Range, '/' + idx, 1)
 
                 ground_sensor_transform = TransformStamped()
-                ground_sensor_transform.header.stamp = self.get_clock().now()
+                ground_sensor_transform.header.stamp = self.get_clock().now().to_msg()
                 ground_sensor_transform.header.frame_id = "base_link"
                 ground_sensor_transform.child_frame_id = "gs" + str(i)
                 ground_sensor_transform.transform.rotation = euler_to_quaternion(0, pi/2, 0)
@@ -141,7 +141,7 @@ class EPuckDriver(WebotsDifferentialDriveNode):
             self.distance_sensor_publishers['ps{}'.format(i)] = sensor_publisher
 
             distance_sensor_transform = TransformStamped()
-            distance_sensor_transform.header.stamp = self.get_clock().now()
+            distance_sensor_transform.header.stamp = self.get_clock().now().to_msg()
             distance_sensor_transform.header.frame_id = "base_link"
             distance_sensor_transform.child_frame_id = "ps" + str(i)
             distance_sensor_transform.transform.rotation = euler_to_quaternion(0, 0, DISTANCE_SENSOR_ANGLE[i])
@@ -157,7 +157,7 @@ class EPuckDriver(WebotsDifferentialDriveNode):
             self.tof_sensor.enable(self.timestep)
             self.tof_publisher = self.create_publisher(Range, '/tof', 1)
             tof_transform = TransformStamped()
-            tof_transform.header.stamp = self.get_clock().now()
+            tof_transform.header.stamp = self.get_clock().now().to_msg()
             tof_transform.header.frame_id = "base_link"
             tof_transform.child_frame_id = "tof"
             tof_transform.transform.rotation.x = 0.0
@@ -217,7 +217,7 @@ class EPuckDriver(WebotsDifferentialDriveNode):
             self.light_sensors.append(light_sensor)
 
             light_transform = TransformStamped()
-            light_transform.header.stamp = self.get_clock().now()
+            light_transform.header.stamp = self.get_clock().now().to_msg()
             light_transform.header.frame_id = "base_link"
             light_transform.child_frame_id = "ls" + str(i)
             light_transform.transform.rotation = euler_to_quaternion(0, 0, DISTANCE_SENSOR_ANGLE[i])
@@ -228,7 +228,7 @@ class EPuckDriver(WebotsDifferentialDriveNode):
 
         # Static tf broadcaster: Laser
         laser_transform = TransformStamped()
-        laser_transform.header.stamp = self.get_clock().now()
+        laser_transform.header.stamp = self.get_clock().now().to_msg()
         laser_transform.header.frame_id = "base_link"
         laser_transform.child_frame_id = "laser_scanner"
         laser_transform.transform.rotation.x = 0.0
@@ -255,7 +255,7 @@ class EPuckDriver(WebotsDifferentialDriveNode):
 
     def step_callback(self):
         self.robot.step(self.timestep)
-        stamp = self.get_clock().now()
+        stamp = self.get_clock().now().to_msg()
 
         self.publish_distance_data(stamp)
         self.publish_light_data(stamp)

--- a/webots_ros2_epuck/webots_ros2_epuck/driver.py
+++ b/webots_ros2_epuck/webots_ros2_epuck/driver.py
@@ -119,7 +119,7 @@ class EPuckDriver(WebotsDifferentialDriveNode):
                 self.ground_sensor_publishers[idx] = self.create_publisher(Range, '/' + idx, 1)
 
                 ground_sensor_transform = TransformStamped()
-                ground_sensor_transform.header.stamp = self.now()
+                ground_sensor_transform.header.stamp = self.get_clock().now()
                 ground_sensor_transform.header.frame_id = "base_link"
                 ground_sensor_transform.child_frame_id = "gs" + str(i)
                 ground_sensor_transform.transform.rotation = euler_to_quaternion(0, pi/2, 0)
@@ -141,7 +141,7 @@ class EPuckDriver(WebotsDifferentialDriveNode):
             self.distance_sensor_publishers['ps{}'.format(i)] = sensor_publisher
 
             distance_sensor_transform = TransformStamped()
-            distance_sensor_transform.header.stamp = self.now()
+            distance_sensor_transform.header.stamp = self.get_clock().now()
             distance_sensor_transform.header.frame_id = "base_link"
             distance_sensor_transform.child_frame_id = "ps" + str(i)
             distance_sensor_transform.transform.rotation = euler_to_quaternion(0, 0, DISTANCE_SENSOR_ANGLE[i])
@@ -157,7 +157,7 @@ class EPuckDriver(WebotsDifferentialDriveNode):
             self.tof_sensor.enable(self.timestep)
             self.tof_publisher = self.create_publisher(Range, '/tof', 1)
             tof_transform = TransformStamped()
-            tof_transform.header.stamp = self.now()
+            tof_transform.header.stamp = self.get_clock().now()
             tof_transform.header.frame_id = "base_link"
             tof_transform.child_frame_id = "tof"
             tof_transform.transform.rotation.x = 0.0
@@ -217,7 +217,7 @@ class EPuckDriver(WebotsDifferentialDriveNode):
             self.light_sensors.append(light_sensor)
 
             light_transform = TransformStamped()
-            light_transform.header.stamp = self.now()
+            light_transform.header.stamp = self.get_clock().now()
             light_transform.header.frame_id = "base_link"
             light_transform.child_frame_id = "ls" + str(i)
             light_transform.transform.rotation = euler_to_quaternion(0, 0, DISTANCE_SENSOR_ANGLE[i])
@@ -228,7 +228,7 @@ class EPuckDriver(WebotsDifferentialDriveNode):
 
         # Static tf broadcaster: Laser
         laser_transform = TransformStamped()
-        laser_transform.header.stamp = self.now()
+        laser_transform.header.stamp = self.get_clock().now()
         laser_transform.header.frame_id = "base_link"
         laser_transform.child_frame_id = "laser_scanner"
         laser_transform.transform.rotation.x = 0.0
@@ -255,7 +255,7 @@ class EPuckDriver(WebotsDifferentialDriveNode):
 
     def step_callback(self):
         self.robot.step(self.timestep)
-        stamp = self.now()
+        stamp = self.get_clock().now()
 
         self.publish_distance_data(stamp)
         self.publish_light_data(stamp)

--- a/webots_ros2_epuck/webots_ros2_epuck/driver.py
+++ b/webots_ros2_epuck/webots_ros2_epuck/driver.py
@@ -17,6 +17,7 @@
 from functools import partial
 from math import pi, cos, sin
 import rclpy
+from rclpy.time import Time
 from std_msgs.msg import Bool, Int32
 from tf2_ros import StaticTransformBroadcaster
 from sensor_msgs.msg import Range, Image, CameraInfo, Imu, LaserScan, Illuminance
@@ -119,7 +120,7 @@ class EPuckDriver(WebotsDifferentialDriveNode):
                 self.ground_sensor_publishers[idx] = self.create_publisher(Range, '/' + idx, 1)
 
                 ground_sensor_transform = TransformStamped()
-                ground_sensor_transform.header.stamp = self.get_clock().now().to_msg()
+                ground_sensor_transform.header.stamp = Time(seconds=self.robot.getTime()).to_msg()
                 ground_sensor_transform.header.frame_id = "base_link"
                 ground_sensor_transform.child_frame_id = "gs" + str(i)
                 ground_sensor_transform.transform.rotation = euler_to_quaternion(0, pi/2, 0)
@@ -141,7 +142,7 @@ class EPuckDriver(WebotsDifferentialDriveNode):
             self.distance_sensor_publishers['ps{}'.format(i)] = sensor_publisher
 
             distance_sensor_transform = TransformStamped()
-            distance_sensor_transform.header.stamp = self.get_clock().now().to_msg()
+            distance_sensor_transform.header.stamp = Time(seconds=self.robot.getTime()).to_msg()
             distance_sensor_transform.header.frame_id = "base_link"
             distance_sensor_transform.child_frame_id = "ps" + str(i)
             distance_sensor_transform.transform.rotation = euler_to_quaternion(0, 0, DISTANCE_SENSOR_ANGLE[i])
@@ -157,7 +158,7 @@ class EPuckDriver(WebotsDifferentialDriveNode):
             self.tof_sensor.enable(self.timestep)
             self.tof_publisher = self.create_publisher(Range, '/tof', 1)
             tof_transform = TransformStamped()
-            tof_transform.header.stamp = self.get_clock().now().to_msg()
+            tof_transform.header.stamp = Time(seconds=self.robot.getTime()).to_msg()
             tof_transform.header.frame_id = "base_link"
             tof_transform.child_frame_id = "tof"
             tof_transform.transform.rotation.x = 0.0
@@ -217,7 +218,7 @@ class EPuckDriver(WebotsDifferentialDriveNode):
             self.light_sensors.append(light_sensor)
 
             light_transform = TransformStamped()
-            light_transform.header.stamp = self.get_clock().now().to_msg()
+            light_transform.header.stamp = Time(seconds=self.robot.getTime()).to_msg()
             light_transform.header.frame_id = "base_link"
             light_transform.child_frame_id = "ls" + str(i)
             light_transform.transform.rotation = euler_to_quaternion(0, 0, DISTANCE_SENSOR_ANGLE[i])
@@ -228,7 +229,7 @@ class EPuckDriver(WebotsDifferentialDriveNode):
 
         # Static tf broadcaster: Laser
         laser_transform = TransformStamped()
-        laser_transform.header.stamp = self.get_clock().now().to_msg()
+        laser_transform.header.stamp = Time(seconds=self.robot.getTime()).to_msg()
         laser_transform.header.frame_id = "base_link"
         laser_transform.child_frame_id = "laser_scanner"
         laser_transform.transform.rotation.x = 0.0
@@ -255,7 +256,7 @@ class EPuckDriver(WebotsDifferentialDriveNode):
 
     def step_callback(self):
         self.robot.step(self.timestep)
-        stamp = self.get_clock().now().to_msg()
+        stamp = Time(seconds=self.robot.getTime()).to_msg()
 
         self.publish_distance_data(stamp)
         self.publish_light_data(stamp)


### PR DESCRIPTION
**Description**
Nanoseconds are not calculated properly.

**Related Issues**
Fixes #71

**Affected Packages**
  - webots_ros2_core
  - webots_ros2_epuck
  - webots_ros2_demos

**Tasks**
  - [x] Decide wether to deprecate `.now()` method in favor of `self.get_clock().now().to_msg()` or to fix it
  - [x] Fix time usage in:
    - [x] `driver.py` (epuck), 
    - [x] `trajectory_follower.py`,
    - [x] `follow_joint_trajectory_client.py`,
    - [x] `tf_publisher.py` and
    - [x] `laser_publisher.py` (not tested)
  - [x] Increase line length in `webots_ros2_core`

**Additional Context**
- Users can use either `Time(seconds=self.robot.getTime()).to_msg()` or `self.get_clock().now().to_msg()`