### PR TITLE
Replace exit by sys.exit.

### DIFF
--- a/webots_ros2_core/webots_ros2_core/webots_differential_drive_node.py
+++ b/webots_ros2_core/webots_ros2_core/webots_differential_drive_node.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import argparse
+import sys
 from math import cos, sin
 import rclpy
 from rclpy.time import Time
@@ -58,7 +59,7 @@ class WebotsDifferentialDriveNode(WebotsNode):
         if self._wheel_radius == 0 or self._wheel_distance == 0:
             self.get_logger().error('Parameters `wheel_distance` and `wheel_radius` have to greater than 0')
             self.destroy_node()
-            exit(1)
+            sys.exit(1)
         self.get_logger().info(
             f'Initializing differential drive node with wheel_distance = {self._wheel_distance} and ' +
             f'wheel_radius = {self._wheel_radius}'

--- a/webots_ros2_epuck/webots_ros2_epuck/drive_calibrator.py
+++ b/webots_ros2_epuck/webots_ros2_epuck/drive_calibrator.py
@@ -16,6 +16,7 @@
 # by moving the robot forward and correcting wheel radius, and rotating robot and
 # correcting distance between the wheels.
 
+import sys
 import time
 from math import pi
 import rclpy
@@ -55,7 +56,7 @@ class EPuckDriveCalibrator(Node):
         self.get_logger().info('The robot has reached the given pose according to odometry')
         time.sleep(0.5)
         self.destroy_node()
-        exit(0)
+        sys.exit(0)
 
     def set_velocity(self, linear, angular):
         msg = Twist()


### PR DESCRIPTION
**Description**
Using sys.exit is recommended instead of using directly exit (because for example this handles exceptions).
