### PR TITLE
Fix Bloom Release (last attempt)

### DIFF
--- a/.github/workflows/bloom-release.yml
+++ b/.github/workflows/bloom-release.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: bloom release
-        uses: DavidMansolino/bloom-release-action@v0.0.12
+        uses: at-wat/bloom-release-action@v0.0.8
         with:
           ros_distro: eloquent foxy
           github_token_bloom: ${{ secrets.BLOOM_TOKEN }}
@@ -17,5 +17,4 @@ jobs:
           git_user: DavidMansolino
           git_email: David.Mansolino@cyberbotics.com
           release_repository_push_url: https://github.com/${{ github.repository }}-release.git
-          version_branch: true 
           # open_pr: true


### PR DESCRIPTION
**Description**
Ok, I think I understood how it works, there is no way to set the branch, even by forking the action for switching branch with git, because the repo is not cloned locally.
Instead, bloom-release will look in rosdep which branch is configured for this ros version and use it automatically. 