### PR TITLE
Remove Eloquent from Workflow

### DIFF
--- a/.github/workflows/bloom-release.yml
+++ b/.github/workflows/bloom-release.yml
@@ -11,7 +11,7 @@ jobs:
       - name: bloom release
         uses: at-wat/bloom-release-action@v0.0.8
         with:
-          ros_distro: eloquent foxy
+          ros_distro: foxy
           github_token_bloom: ${{ secrets.BLOOM_TOKEN }}
           github_user: DavidMansolino
           git_user: DavidMansolino


### PR DESCRIPTION
**Description**

The first release on a new ros version has to be created manually (which is not done for eloquent yet, but for foxy).