### PR TITLE
Use motor name for Joint_states_publisher

### DIFF
--- a/webots_ros2_core/webots_ros2_core/joint_state_publisher.py
+++ b/webots_ros2_core/webots_ros2_core/joint_state_publisher.py
@@ -47,7 +47,7 @@ class JointStatePublisher():
             device = robot.getDeviceByIndex(i)
             if device.getNodeType() == Node.POSITION_SENSOR:
                 motor = device.getMotor()
-                name = motor.getName()
+                name = motor.getName() if motor is not None else device.getName()
                 self.jointNames.append(name)
                 self.sensors.append(device)
                 self.previousPosition.append(0)

--- a/webots_ros2_core/webots_ros2_core/joint_state_publisher.py
+++ b/webots_ros2_core/webots_ros2_core/joint_state_publisher.py
@@ -46,7 +46,8 @@ class JointStatePublisher():
         for i in range(robot.getNumberOfDevices()):
             device = robot.getDeviceByIndex(i)
             if device.getNodeType() == Node.POSITION_SENSOR:
-                name = device.getName()
+                motor = device.getMotor()
+                name = motor.getName()
                 self.jointNames.append(name)
                 self.sensors.append(device)
                 self.previousPosition.append(0)


### PR DESCRIPTION
Use the name of the motor instead the name of the positionSensor as the published joint name. This is more consistent with ROS convention 