### PR TITLE
Use wget to get Webots instead of urllib.

### DIFF
--- a/webots_ros2_desktop/package.xml
+++ b/webots_ros2_desktop/package.xml
@@ -11,6 +11,8 @@
   <url type="bugtracker">https://github.com/cyberbotics/webots_ros2/issues</url>
   <url type="repository">https://github.com/cyberbotics/webots_ros2</url>
 
+  <build_depend>wget</build_depend>
+
   <exec_depend>rclpy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>builtin_interfaces</exec_depend>

--- a/webots_ros2_desktop/setup.py
+++ b/webots_ros2_desktop/setup.py
@@ -4,7 +4,6 @@ import os
 import shutil
 import sys
 import tarfile
-import urllib.request
 
 from setuptools import setup
 
@@ -25,8 +24,7 @@ if 'WEBOTS_HOME' not in os.environ and 'TRAVIS' not in os.environ and sys.platfo
         shutil.rmtree('webots')
     # Get Webots archive
     url = 'https://github.com/cyberbotics/webots/releases/download/%s/' % webotsVersion
-    urllib.request.urlretrieve(url + archiveName,
-                               os.path.join(os.path.dirname(__file__), archiveName))
+    os.system('wget ' + url + archiveName + ' -O ' + os.path.join(os.path.dirname(__file__), archiveName))
     # Extract Webots archive
     tar = tarfile.open(archiveName, 'r:bz2')
     tar.extractall()


### PR DESCRIPTION
**Description**
Currently the download of Webots with urlib is failing on the ros buildfarm, I found one package (`fzi_icl_can`) that is using wget successfully on the buildfarm.

It is an old package and a different version of ROS (and therefore the ROS1 buildfarm and not ROS2), but it is worth
 trying.