### PR TITLE
Add C++ example

### DIFF
--- a/webots_ros2_cpp/CMakeLists.txt
+++ b/webots_ros2_cpp/CMakeLists.txt
@@ -1,0 +1,49 @@
+cmake_minimum_required(VERSION 3.5)
+project(webots_ros2_cpp)
+
+# Compiler
+if(NOT CMAKE_C_STANDARD)
+  set(CMAKE_C_STANDARD 99)
+endif()
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# Webots
+link_directories($ENV{WEBOTS_HOME}/lib/controller)
+set(
+  WEBOTS_LIB
+  ${CMAKE_SHARED_LIBRARY_PREFIX}Controller${CMAKE_SHARED_LIBRARY_SUFFIX}
+  ${CMAKE_SHARED_LIBRARY_PREFIX}CppController${CMAKE_SHARED_LIBRARY_SUFFIX})
+include_directories(
+  $ENV{WEBOTS_HOME}/include/controller/c
+  $ENV{WEBOTS_HOME}/include/controller/cpp
+)
+
+message($ENV{WEBOTS_HOME}/lib/controller)
+
+# ROS2
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(sensor_msgs REQUIRED)
+add_executable(driver src/driver.cpp)
+target_include_directories(driver PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>)
+target_link_libraries(driver
+  ${WEBOTS_LIB}
+)
+ament_target_dependencies(driver rclcpp sensor_msgs)
+install(TARGETS driver
+  DESTINATION lib/${PROJECT_NAME})
+
+
+# Testing
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+ament_package()

--- a/webots_ros2_cpp/CMakeLists.txt
+++ b/webots_ros2_cpp/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 project(webots_ros2_cpp)
 
+
 # Compiler
 if(NOT CMAKE_C_STANDARD)
   set(CMAKE_C_STANDARD 99)
@@ -11,6 +12,7 @@ endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
+
 
 # Webots
 link_directories($ENV{WEBOTS_HOME}/lib/controller)
@@ -23,7 +25,6 @@ include_directories(
   $ENV{WEBOTS_HOME}/include/controller/cpp
 )
 
-message($ENV{WEBOTS_HOME}/lib/controller)
 
 # ROS2
 find_package(ament_cmake REQUIRED)

--- a/webots_ros2_cpp/package.xml
+++ b/webots_ros2_cpp/package.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>webots_ros2_cpp</name>
+  <version>1.0.3</version>
+  <description>Webots robot driver written in C++</description>
+  <maintainer email="support@cyberbotics.com">Cyberbotics</maintainer>
+  <license>Apache License 2.0</license>
+  <url type="website">http://wiki.ros.org/webots_ros2</url>
+  <url type="bugtracker">https://github.com/cyberbotics/webots_ros2/issues</url>
+  <url type="repository">https://github.com/cyberbotics/webots_ros2</url>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <depend>rclcpp</depend>
+  <depend>sensor_msgs</depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/webots_ros2_cpp/resources/ros2webots/ros2webots
+++ b/webots_ros2_cpp/resources/ros2webots/ros2webots
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+source /opt/ros/foxy/local_setup.bash
+source $HOME/foxy_ws/install/local_setup.bash
+
+ros2 run webots_ros2_cpp driver $@

--- a/webots_ros2_cpp/src/driver.cpp
+++ b/webots_ros2_cpp/src/driver.cpp
@@ -1,5 +1,3 @@
-// export LD_LIBRARY_PATH=${WEBOTS_HOME}/lib/controller
-
 #include <chrono>
 #include <functional>
 #include <memory>

--- a/webots_ros2_cpp/src/driver.cpp
+++ b/webots_ros2_cpp/src/driver.cpp
@@ -1,0 +1,54 @@
+// export LD_LIBRARY_PATH=${WEBOTS_HOME}/lib/controller
+
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <string>
+
+// Webots dependencies
+#include <webots/Robot.hpp>
+#include <webots/DistanceSensor.hpp>
+
+// ROS2 dependencies
+#include "rclcpp/rclcpp.hpp"
+#include "sensor_msgs/msg/range.hpp"
+
+
+class DriverNode : public rclcpp::Node
+{
+public:
+  DriverNode() : Node("webots_driver_node"), mTimeStep(64)
+  {
+    // For Pioneer 3-DX
+    mRobot = new webots::Robot();
+    mDistanceSensor = mRobot->getDistanceSensor("so4");
+    mDistanceSensor->enable(mTimeStep);
+
+    mPublisher = this->create_publisher<sensor_msgs::msg::Range>("/range", 1);
+    mTimer = this->create_wall_timer(std::chrono::milliseconds(mTimeStep), std::bind(&DriverNode::timerCallback, this));
+  }
+
+private:
+  void timerCallback()
+  {
+    mRobot->step(mTimeStep);
+
+    auto message = sensor_msgs::msg::Range();
+    message.range = mDistanceSensor->getValue();
+    mPublisher->publish(message);
+  }
+
+  webots::Robot *mRobot;
+  webots::DistanceSensor *mDistanceSensor;
+  rclcpp::TimerBase::SharedPtr mTimer;
+  rclcpp::Publisher<sensor_msgs::msg::Range>::SharedPtr mPublisher;
+  int mTimeStep;
+};
+
+int main(int argc, char *argv[])
+{
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<DriverNode>());
+  rclcpp::shutdown();
+  return 0;
+}


### PR DESCRIPTION
This PR shows it is possible to write Webots ROS2 drivers in C++.

**Affected Packages**
  - webots_ros2_cpp

**Tasks**
  - [x] Add a simple example
  - [ ] Explore downsides of users writing C++ drivers
  - [ ] Write a tutorial

**Usage**

As an external controller:
```bash
# first terminal
webots ${WEBOTS_HOME}/projects/robots/adept/pioneer3/worlds/pioneer3dx.wbt
# change the robot's `controller` field to `<extern>`

# second termianl
export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${WEBOTS_HOME}/lib/controller
cd /path/to/ros2_ws
source /opt/ros/foxy/local_setup.bash
colcon build --packages-select webots_ros2_cpp
source install/local_setup.bash
ros2 run webots_ros2_cpp driver
```

As a standalone controller:
- Make sure your controller is compiled.
- Copy `webots_ros2_cpp/resources/ros2webots` to your controller directory.
- Select controller `ros2webots` in the robot's `controller` field.