### PR TITLE
Add `lark` dependency

### DIFF
--- a/webots_ros2_importer/package.xml
+++ b/webots_ros2_importer/package.xml
@@ -13,6 +13,7 @@
 
   <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>python3-collada</exec_depend>
+  <exec_depend>python3-lark</exec_depend>
   <exec_depend>xacro</exec_depend>
 
   <!-- These test dependencies are optional

--- a/webots_ros2_importer/package.xml
+++ b/webots_ros2_importer/package.xml
@@ -13,7 +13,7 @@
 
   <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>python3-collada</exec_depend>
-  <exec_depend>python3-lark</exec_depend>
+  <exec_depend>python3-lark-parser</exec_depend>
   <exec_depend>xacro</exec_depend>
 
   <!-- These test dependencies are optional


### PR DESCRIPTION
Fixes #183

`lark` is dependency of `launch` that typically gets installed with `ros-base`, so we didn't notice it earlier:
https://github.com/ros2/launch/blob/55ca523ff0053e1c7932debaa7366e33180c23a6/launch/package.xml#L17