### PR TITLE
Fix crash on no line detection (#214)

### DIFF
--- a/webots_ros2_tesla/webots_ros2_tesla/lane_follower.py
+++ b/webots_ros2_tesla/webots_ros2_tesla/lane_follower.py
@@ -23,7 +23,7 @@ from rclpy.qos import qos_profile_sensor_data
 from rclpy.node import Node
 
 
-CONTROL_COEFFICIENT = 0.002
+CONTROL_COEFFICIENT = 0.0005
 
 
 class LaneFollower(Node):
@@ -41,22 +41,27 @@ class LaneFollower(Node):
 
         # Segment the image by color in HSV color space
         img = cv2.cvtColor(img, cv2.COLOR_RGB2HSV)
-        mask = cv2.inRange(img, np.array([70, 120, 170]), np.array([120, 160, 210]))
+        mask = cv2.inRange(img, np.array([50, 110, 150]), np.array([120, 255, 255]))
 
         # Find the largest segmented contour
         contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_NONE)
+
+        command_message = AckermannDrive()
+        command_message.speed = 50.0
+        command_message.steering_angle = 0.0
+
         if contours:
+            
             largest_contour = max(contours, key=cv2.contourArea)
             largest_contour_center = cv2.moments(largest_contour)
-            center_x = int(largest_contour_center['m10'] / largest_contour_center['m00'])
 
-            # Find error (the lane distance from the target distance)
-            error = center_x - 120
-
-            command_message = AckermannDrive()
-            command_message.speed = 10.0
-            command_message.steering_angle = error * CONTROL_COEFFICIENT
-            self.__ackermann_publisher.publish(command_message)
+            if largest_contour_center['m00'] != 0:
+                center_x = int(largest_contour_center['m10'] / largest_contour_center['m00'])
+                # Find error (the lane distance from the target distance)
+                error = center_x - 190
+                command_message.steering_angle = error*CONTROL_COEFFICIENT
+        
+        self.__ackermann_publisher.publish(command_message)
 
 
 def main(args=None):

--- a/webots_ros2_tesla/webots_ros2_tesla/lane_follower.py
+++ b/webots_ros2_tesla/webots_ros2_tesla/lane_follower.py
@@ -51,7 +51,6 @@ class LaneFollower(Node):
         command_message.steering_angle = 0.0
 
         if contours:
-            
             largest_contour = max(contours, key=cv2.contourArea)
             largest_contour_center = cv2.moments(largest_contour)
 
@@ -60,7 +59,7 @@ class LaneFollower(Node):
                 # Find error (the lane distance from the target distance)
                 error = center_x - 190
                 command_message.steering_angle = error*CONTROL_COEFFICIENT
-        
+
         self.__ackermann_publisher.publish(command_message)
 
 


### PR DESCRIPTION
**Description**
Fixing a bug where the lane_follower node crashes when the road central line is not detected (E.G. at a crossroad). Also adjusted lower and upper bounds for color detection, as well as control coefficient for smoother running.

**Related Issues**
This pull-request fixes issue #214 

**Affected Packages**
List of affected packages:
  - webots_ros2_tesla

**Additional context**

The Ackermannrive message is instantiated before checking for contours in the image, with default values for speed = 50 and steering_angle = 0.0. If contours are detected, then steering_angle is recalculated accordingly. To avoid float division by 0 (which was causing the issue), a further check is inserted for the m00 moment of the largest contour center to be nonzero.
Previous boundaries for color detection: (70,120,170), (120,160,210)
New boundaries for color detection: (50,110,150), (120, 255, 255)
