### PR TITLE
Bump the version number

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         ROS_REPO: [main, testing]
-        ROS_DISTRO: [foxy, rolling]
+        ROS_DISTRO: [foxy]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/webots_ros2/package.xml
+++ b/webots_ros2/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>webots_ros2</name>
-  <version>1.0.5</version>
+  <version>1.0.6</version>
   <description>Interface between Webots and ROS2</description>
 
   <maintainer email="support@cyberbotics.com">Cyberbotics</maintainer>

--- a/webots_ros2/setup.py
+++ b/webots_ros2/setup.py
@@ -6,7 +6,7 @@ package_name = 'webots_ros2'
 
 setup(
     name=package_name,
-    version='1.0.5',
+    version='1.0.6',
     packages=[package_name],
     data_files=[
         ('share/' + package_name, ['package.xml']),

--- a/webots_ros2_abb/package.xml
+++ b/webots_ros2_abb/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>webots_ros2_abb</name>
-  <version>1.0.5</version>
+  <version>1.0.6</version>
   <description>ABB robots ROS2 interface for Webots.</description>
 
   <maintainer email="support@cyberbotics.com">Cyberbotics</maintainer>

--- a/webots_ros2_abb/setup.py
+++ b/webots_ros2_abb/setup.py
@@ -14,7 +14,7 @@ data_files.append(('share/' + package_name, ['package.xml']))
 
 setup(
     name=package_name,
-    version='1.0.5',
+    version='1.0.6',
     packages=[],
     data_files=data_files,
     install_requires=['setuptools', 'launch'],

--- a/webots_ros2_core/package.xml
+++ b/webots_ros2_core/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>webots_ros2_core</name>
-  <version>1.0.5</version>
+  <version>1.0.6</version>
   <description>Core interface between Webots and ROS2</description>
 
   <maintainer email="support@cyberbotics.com">Cyberbotics</maintainer>

--- a/webots_ros2_core/setup.py
+++ b/webots_ros2_core/setup.py
@@ -11,7 +11,7 @@ data_files.append(('share/' + package_name + '/launch', ['launch/robot_launch.py
 
 setup(
     name=package_name,
-    version='1.0.5',
+    version='1.0.6',
     packages=[package_name, package_name + '.devices', package_name + '.math', package_name + '.webots'],
     data_files=data_files,
     install_requires=['setuptools', 'launch'],

--- a/webots_ros2_demos/package.xml
+++ b/webots_ros2_demos/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>webots_ros2_demos</name>
-  <version>1.0.5</version>
+  <version>1.0.6</version>
   <description>Various demos of the Webots-ROS2 interface.</description>
 
   <maintainer email="support@cyberbotics.com">Cyberbotics</maintainer>

--- a/webots_ros2_demos/setup.py
+++ b/webots_ros2_demos/setup.py
@@ -20,7 +20,7 @@ data_files.append(('share/' + package_name, ['package.xml']))
 
 setup(
     name=package_name,
-    version='1.0.5',
+    version='1.0.6',
     packages=[package_name],
     data_files=data_files,
     install_requires=['setuptools', 'launch'],

--- a/webots_ros2_epuck/package.xml
+++ b/webots_ros2_epuck/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>webots_ros2_epuck</name>
-  <version>1.0.5</version>
+  <version>1.0.6</version>
   <description>E-puck2 driver for Webots simulated robot</description>
 
   <maintainer email="support@cyberbotics.com">Cyberbotics</maintainer>

--- a/webots_ros2_epuck/setup.py
+++ b/webots_ros2_epuck/setup.py
@@ -46,7 +46,7 @@ data_files.append(('share/' + package_name, [
 
 setup(
     name=package_name,
-    version='1.0.5',
+    version='1.0.6',
     packages=[package_name],
     data_files=data_files,
     install_requires=['setuptools', 'launch'],

--- a/webots_ros2_examples/package.xml
+++ b/webots_ros2_examples/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>webots_ros2_examples</name>
-  <version>1.0.5</version>
+  <version>1.0.6</version>
   <description>Minimal example showing how to control a robot with ROS2 in Webots.</description>
 
   <maintainer email="support@cyberbotics.com">Cyberbotics</maintainer>

--- a/webots_ros2_examples/setup.py
+++ b/webots_ros2_examples/setup.py
@@ -24,7 +24,7 @@ data_files.append(('share/' + package_name, ['package.xml']))
 
 setup(
     name=package_name,
-    version='1.0.5',
+    version='1.0.6',
     packages=[package_name],
     data_files=data_files,
     install_requires=['setuptools', 'launch'],

--- a/webots_ros2_importer/package.xml
+++ b/webots_ros2_importer/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>webots_ros2_importer</name>
-  <version>1.0.5</version>
+  <version>1.0.6</version>
   <description>This package allows to convert URDF and XACRO files into Webots PROTO files.</description>
 
   <maintainer email="support@cyberbotics.com">Cyberbotics</maintainer>

--- a/webots_ros2_importer/setup.py
+++ b/webots_ros2_importer/setup.py
@@ -10,7 +10,7 @@ data_files.append(('share/' + package_name, ['package.xml']))
 
 setup(
     name=package_name,
-    version='1.0.5',
+    version='1.0.6',
     packages=[package_name, package_name + '.urdf2webots.urdf2webots'],
     data_files=data_files,
     install_requires=[

--- a/webots_ros2_msgs/package.xml
+++ b/webots_ros2_msgs/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>webots_ros2_msgs</name>
-  <version>1.0.5</version>
+  <version>1.0.6</version>
   <description>Services and Messages of the webots_ros2 packages.</description>
 
   <maintainer email="support@cyberbotics.com">Cyberbotics</maintainer>

--- a/webots_ros2_tesla/package.xml
+++ b/webots_ros2_tesla/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>webots_ros2_tesla</name>
-  <version>1.0.5</version>
+  <version>1.0.6</version>
   <description>Tesla ROS2 interface for Webots.</description>
 
   <maintainer email="support@cyberbotics.com">Cyberbotics</maintainer>

--- a/webots_ros2_tesla/setup.py
+++ b/webots_ros2_tesla/setup.py
@@ -16,7 +16,7 @@ data_files.append(('share/' + package_name, ['package.xml']))
 
 setup(
     name=package_name,
-    version='1.0.5',
+    version='1.0.6',
     packages=[package_name],
     data_files=data_files,
     install_requires=['setuptools', 'launch'],

--- a/webots_ros2_tiago/package.xml
+++ b/webots_ros2_tiago/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>webots_ros2_tiago</name>
-  <version>1.0.5</version>
+  <version>1.0.6</version>
   <description>TIAGo robots ROS2 interface for Webots.</description>
 
   <maintainer email="support@cyberbotics.com">Cyberbotics</maintainer>

--- a/webots_ros2_tiago/setup.py
+++ b/webots_ros2_tiago/setup.py
@@ -18,7 +18,7 @@ data_files.append(('share/' + package_name, ['package.xml']))
 
 setup(
     name=package_name,
-    version='1.0.5',
+    version='1.0.6',
     packages=[],
     data_files=data_files,
     install_requires=['setuptools', 'launch'],

--- a/webots_ros2_turtlebot/package.xml
+++ b/webots_ros2_turtlebot/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>webots_ros2_turtlebot</name>
-  <version>1.0.5</version>
+  <version>1.0.6</version>
   <description>TurtleBot3 Burger robot ROS2 interface for Webots.</description>
 
   <maintainer email="support@cyberbotics.com">Cyberbotics</maintainer>

--- a/webots_ros2_turtlebot/setup.py
+++ b/webots_ros2_turtlebot/setup.py
@@ -24,7 +24,7 @@ data_files.append(('share/' + package_name, ['package.xml']))
 
 setup(
     name=package_name,
-    version='1.0.5',
+    version='1.0.6',
     packages=[package_name],
     data_files=data_files,
     install_requires=['setuptools', 'launch'],

--- a/webots_ros2_tutorials/package.xml
+++ b/webots_ros2_tutorials/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>webots_ros2_tutorials</name>
-  <version>1.0.5</version>
+  <version>1.0.6</version>
   <description>This package is made to aid youtube Webots_ROS2 tutorial series</description>
   <maintainer email="harsh.b.kakashaniya@gmail.com">Soft_illusion</maintainer>
   <license>Apache License 2.0</license>

--- a/webots_ros2_tutorials/setup.py
+++ b/webots_ros2_tutorials/setup.py
@@ -44,7 +44,7 @@ data_files.append(('share/' + package_name, [
 
 setup(
     name=package_name,
-    version='1.0.5',
+    version='1.0.6',
     packages=[package_name],
     data_files=data_files,
     install_requires=['setuptools', 'launch'],

--- a/webots_ros2_universal_robot/package.xml
+++ b/webots_ros2_universal_robot/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>webots_ros2_universal_robot</name>
-  <version>1.0.5</version>
+  <version>1.0.6</version>
   <description>Universal Robot ROS2 interface for Webots.</description>
 
   <maintainer email="support@cyberbotics.com">Cyberbotics</maintainer>

--- a/webots_ros2_universal_robot/setup.py
+++ b/webots_ros2_universal_robot/setup.py
@@ -46,7 +46,7 @@ data_files.append(('share/' + package_name + '/resource', ['resource/view_robot_
 
 setup(
     name=package_name,
-    version='1.0.5',
+    version='1.0.6',
     packages=[],
     data_files=data_files,
     install_requires=['setuptools', 'launch'],

--- a/webots_ros2_ur_e_description/package.xml
+++ b/webots_ros2_ur_e_description/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>webots_ros2_ur_e_description</name>
-  <version>1.0.5</version>
+  <version>1.0.6</version>
   <description>Universal Robot description for Webots.</description>
 
   <maintainer email="support@cyberbotics.com">Cyberbotics</maintainer>

--- a/webots_ros2_ur_e_description/setup.py
+++ b/webots_ros2_ur_e_description/setup.py
@@ -32,7 +32,7 @@ data_files.append(('share/' + package_name, ['package.xml']))
 
 setup(
     name=package_name,
-    version='1.0.5',
+    version='1.0.6',
     packages=[package_name],
     data_files=data_files,
     install_requires=['setuptools', 'launch'],


### PR DESCRIPTION
I am also deleting the Rolling tests as there are missing packages: `vision_msgs` and `ackermann_msgs`. I posted an issue about the missing packages:
- https://github.com/ros-perception/vision_msgs/issues/55
- https://github.com/ros-drivers/ackermann_msgs/issues/14#issuecomment-816511743

As soon as the packages are available I will enable the CI tests for Rolling. Now, the plan is to create a `rolling` branch and delete all our packages that depend on the missing packages.