### PR TITLE
Revise argument's type of WebotsNode init func

### DIFF
--- a/webots_ros2_core/webots_ros2_core/webots_node.py
+++ b/webots_ros2_core/webots_ros2_core/webots_node.py
@@ -39,7 +39,7 @@ class WebotsNode(Node):
     Extends ROS2 base node to provide integration with Webots.
 
     Args:
-        name (WebotsNode): Webots Robot node.
+        name (str): Webots Robot node.
         args (dict): Arguments passed to ROS2 base node.
     """
 


### PR DESCRIPTION
**Description**
Arg `name` is only used in `super().__init__(name)` which is init function of rclpy.node.Node

In rclpy/node.py :
``` python
class Node:

    PARAM_REL_TOL = 1e-6

    """
    A Node in the ROS graph.

    A Node is the primary entrypoint in a ROS system for communication.
    It can be used to create ROS entities such as publishers, subscribers, services, etc.
    """

    def __init__(
        self,
        node_name: str,
        *,
        context: Context = None,
        cli_args: List[str] = None,
        namespace: str = None,
        use_global_arguments: bool = True,
        enable_rosout: bool = True,
        start_parameter_services: bool = True,
        parameter_overrides: List[Parameter] = None,
        allow_undeclared_parameters: bool = False,
        automatically_declare_parameters_from_overrides: bool = False
    ) -> None:
```

So, revise the arg type in docstring from `WebotNode` to `str` to prevent warning from pycharm