### PR TITLE
Fix warnings

### DIFF
--- a/webots_ros2_control/src/Ros2Control.cpp
+++ b/webots_ros2_control/src/Ros2Control.cpp
@@ -37,10 +37,9 @@ namespace webots_ros2_control
     mControllerManager->write();
   }
 
-  void Ros2Control::init(webots_ros2_driver::WebotsNode *node, std::unordered_map<std::string, std::string> &parameters)
+  void Ros2Control::init(webots_ros2_driver::WebotsNode *node, std::unordered_map<std::string, std::string> &)
   {
     mNode = node;
-    (void)parameters;
 
     // Load hardware
     try

--- a/webots_ros2_control/src/Ros2Control.cpp
+++ b/webots_ros2_control/src/Ros2Control.cpp
@@ -40,6 +40,7 @@ namespace webots_ros2_control
   void Ros2Control::init(webots_ros2_driver::WebotsNode *node, std::unordered_map<std::string, std::string> &parameters)
   {
     mNode = node;
+    (void)parameters;
 
     // Load hardware
     try

--- a/webots_ros2_tiago/worlds/ros_tiago.wbt
+++ b/webots_ros2_tiago/worlds/ros_tiago.wbt
@@ -403,10 +403,6 @@ RectangularPanel {
 DirectionPanel {
   translation 8 5 1.5
   rotation -1 0 0 4.71238898038469
-  textSize 0.175
-  text "Fresh beer :)"
-  right FALSE
-  left TRUE
 }
 BunchOfSunFlowers {
   translation 7.68 -0.52 0.5

--- a/webots_ros2_turtlebot/worlds/turtlebot3_burger_example.wbt
+++ b/webots_ros2_turtlebot/worlds/turtlebot3_burger_example.wbt
@@ -206,10 +206,6 @@ Table {
 DirectionPanel {
   translation 8 5 1.5
   rotation 1 0 0 1.571
-  textSize 0.175
-  text "Fresh beer :)"
-  right FALSE
-  left TRUE
 }
 BunchOfSunFlowers {
   translation 7.68 -0.52 0.5


### PR DESCRIPTION
The change in `Ros2Control.cpp` fixes the following warning:
```
/home/lukic/foxy_ws/src/webots_ros2/webots_ros2_control/src/Ros2Control.cpp:40:110: warning: unused parameter ‘parameters’ [-Wunused-parameter]
```

Some parameters in the `DirectionPanel` are deleted, so we have to delete them in the world file as well.