### PR TITLE
Fix Windows build

### DIFF
--- a/webots_ros2_driver/CMakeLists.txt
+++ b/webots_ros2_driver/CMakeLists.txt
@@ -142,6 +142,13 @@ install(
   DIRECTORY ${WEBOTS_LIB_BASE}/
   DESTINATION lib/
 )
+if (MSVC OR MSYS OR MINGW OR WIN32)
+  # Windows requires the library to be placed with executable
+  install(
+    FILES "${WEBOTS_LIB_BASE}/${CMAKE_SHARED_LIBRARY_PREFIX}Controller${CMAKE_SHARED_LIBRARY_SUFFIX}"
+    DESTINATION lib/${PROJECT_NAME}
+  )
+endif()
 
 # Prevent pluginlib from using boost
 target_compile_definitions(driver PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")

--- a/webots_ros2_driver/CMakeLists.txt
+++ b/webots_ros2_driver/CMakeLists.txt
@@ -4,6 +4,20 @@ project(webots_ros2_driver)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# ROS2 Packages
+find_package(ament_cmake REQUIRED)
+find_package(rosgraph_msgs REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(pluginlib REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(tf2_ros REQUIRED)
+find_package(vision_msgs REQUIRED)
+find_package(webots_ros2_msgs REQUIRED)
+find_package(tinyxml2_vendor REQUIRED)
+find_package(TinyXML2 REQUIRED)
+
 if (UNIX AND NOT APPLE)
   set(WEBOTS_LIB_BASE webots/lib/linux-gnu)
 endif ()
@@ -22,6 +36,9 @@ include_directories(
 link_directories(${WEBOTS_LIB_BASE})
 
 if (MSVC OR MSYS OR MINGW OR WIN32)
+  # Windows requires the libController C++ part to be compiled.
+  # See more here: https://cyberbotics.com/doc/guide/using-your-ide#visual-studio
+
   set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
   file(GLOB CppController_SRC CONFIGURE_DEPENDS "webots/source/cpp/*.cpp")
   add_library(
@@ -39,26 +56,13 @@ if (MSVC OR MSYS OR MINGW OR WIN32)
     ${CMAKE_SHARED_LIBRARY_PREFIX}Controller${CMAKE_SHARED_LIBRARY_SUFFIX}
     CppController
   )
+  ament_export_libraries(CppController)
 else()
   set(WEBOTS_LIB
     ${CMAKE_SHARED_LIBRARY_PREFIX}Controller${CMAKE_SHARED_LIBRARY_SUFFIX}
     ${CMAKE_SHARED_LIBRARY_PREFIX}CppController${CMAKE_SHARED_LIBRARY_SUFFIX}
   )
 endif()
-
-# ROS2 Packages
-find_package(ament_cmake REQUIRED)
-find_package(rosgraph_msgs REQUIRED)
-find_package(rclcpp REQUIRED)
-find_package(pluginlib REQUIRED)
-find_package(rclcpp_lifecycle REQUIRED)
-find_package(sensor_msgs REQUIRED)
-find_package(std_msgs REQUIRED)
-find_package(tf2_ros REQUIRED)
-find_package(vision_msgs REQUIRED)
-find_package(webots_ros2_msgs REQUIRED)
-find_package(tinyxml2_vendor REQUIRED)
-find_package(TinyXML2 REQUIRED)
 
 add_executable(driver
   src/Driver.cpp

--- a/webots_ros2_driver/CMakeLists.txt
+++ b/webots_ros2_driver/CMakeLists.txt
@@ -4,25 +4,47 @@ project(webots_ros2_driver)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-if (UNIX)
+if (UNIX AND NOT APPLE)
   set(WEBOTS_LIB_BASE webots/lib/linux-gnu)
-endif (UNIX)
-if (WIN32)
-  set(WEBOTS_LIB_BASE webots/lib/msys)
-endif (WIN32)
-if (MSVC)
+endif ()
+if (APPLE)
   set(WEBOTS_LIB_BASE webots/lib/darwin19)
-endif (MSVC)
-link_directories(${WEBOTS_LIB_BASE})
-set(WEBOTS_LIB
-  ${CMAKE_SHARED_LIBRARY_PREFIX}Controller${CMAKE_SHARED_LIBRARY_SUFFIX}
-  ${CMAKE_SHARED_LIBRARY_PREFIX}CppController${CMAKE_SHARED_LIBRARY_SUFFIX}
-)
+endif ()
+if (MSVC OR MSYS OR MINGW OR WIN32)
+  set(WEBOTS_LIB_BASE webots/lib/msys)
+endif ()
+
 include_directories(
   include
   webots/include/c
   webots/include/cpp
 )
+link_directories(${WEBOTS_LIB_BASE})
+
+if (MSVC OR MSYS OR MINGW OR WIN32)
+  set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+  file(GLOB CppController_SRC CONFIGURE_DEPENDS "webots/source/cpp/*.cpp")
+  add_library(
+    CppController
+    SHARED
+    ${CppController_SRC}
+  )
+  target_link_libraries(CppController
+    ${CMAKE_SHARED_LIBRARY_PREFIX}Controller${CMAKE_SHARED_LIBRARY_SUFFIX}
+  )
+  install(TARGETS CppController
+    LIBRARY DESTINATION lib
+  )
+  set(WEBOTS_LIB
+    ${CMAKE_SHARED_LIBRARY_PREFIX}Controller${CMAKE_SHARED_LIBRARY_SUFFIX}
+    CppController
+  )
+else()
+  set(WEBOTS_LIB
+    ${CMAKE_SHARED_LIBRARY_PREFIX}Controller${CMAKE_SHARED_LIBRARY_SUFFIX}
+    ${CMAKE_SHARED_LIBRARY_PREFIX}CppController${CMAKE_SHARED_LIBRARY_SUFFIX}
+  )
+endif()
 
 # ROS2 Packages
 find_package(ament_cmake REQUIRED)

--- a/webots_ros2_driver/src/plugins/static/Ros2Camera.cpp
+++ b/webots_ros2_driver/src/plugins/static/Ros2Camera.cpp
@@ -134,7 +134,6 @@ namespace webots_ros2_driver
       // Object Info -> Detection2D
       vision_msgs::msg::Detection2D detection;
       vision_msgs::msg::ObjectHypothesisWithPose hypothesis;
-      hypothesis.id = std::string(objects[i].model);
       hypothesis.pose.pose.position = position;
       hypothesis.pose.pose.orientation = orientation;
       detection.results.push_back(hypothesis);

--- a/webots_ros2_turtlebot/launch/robot_launch.py
+++ b/webots_ros2_turtlebot/launch/robot_launch.py
@@ -40,7 +40,7 @@ def generate_launch_description():
 
     # TODO: Revert once the https://github.com/ros-controls/ros2_control/pull/444 PR gets into the release
     controller_manager_timeout = ['--controller-manager-timeout', '50'] if os.name == 'nt' else []
-    controller_manager_prefix = 'python.exe' if os.name == 'nt' else "bash -c 'sleep 10; $0 $@' " 
+    controller_manager_prefix = 'python.exe' if os.name == 'nt' else "bash -c 'sleep 10; $0 $@' "
 
     diffdrive_controller_spawner = Node(
         package='controller_manager',

--- a/webots_ros2_turtlebot/launch/robot_launch.py
+++ b/webots_ros2_turtlebot/launch/robot_launch.py
@@ -38,20 +38,24 @@ def generate_launch_description():
         world=PathJoinSubstitution([package_dir, 'worlds', world])
     )
 
+    # TODO: Revert once the https://github.com/ros-controls/ros2_control/pull/444 PR gets into the release
+    controller_manager_timeout = ['--controller-manager-timeout', '50'] if os.name == 'nt' else []
+    controller_manager_prefix = 'python.exe' if os.name == 'nt' else "bash -c 'sleep 10; $0 $@' " 
+
     diffdrive_controller_spawner = Node(
         package='controller_manager',
         executable='spawner.py',
         output='screen',
-        prefix="bash -c 'sleep 10; $0 $@' ",
-        arguments=['diffdrive_controller'],
+        prefix=controller_manager_prefix,
+        arguments=['diffdrive_controller'] + controller_manager_timeout,
     )
 
     joint_state_broadcaster_spawner = Node(
         package='controller_manager',
         executable='spawner.py',
         output='screen',
-        prefix="bash -c 'sleep 10; $0 $@' ",
-        arguments=['joint_state_broadcaster'],
+        prefix=controller_manager_prefix,
+        arguments=['joint_state_broadcaster'] + controller_manager_timeout,
     )
 
     turtlebot_driver = Node(


### PR DESCRIPTION
This PR attempts to fix the Windows build. There was a series of issues:
- The C++ libController library has to be compiled, it cannot be linked.
- The libController couldn't be linked as it was in the wrong place (Windows only).
- The `id` parameter in the `ObjectHypothesisWithPose` message is deprecated.
- The controller spawners were broken in Windows.

**Notes**
```
colcon build --event-handlers console_cohesion+ --packages-select webots_ros2_driver
```