### PR TITLE
Use ros2 node clock for message timestamping

### DIFF
--- a/webots_ros2_driver/src/plugins/dynamic/Ros2IMU.cpp
+++ b/webots_ros2_driver/src/plugins/dynamic/Ros2IMU.cpp
@@ -100,7 +100,7 @@ namespace webots_ros2_driver
 
   void Ros2IMU::publishData()
   {
-    mMessage.header.stamp = rclcpp::Clock().now();
+    mMessage.header.stamp = mNode->get_clock()->now();
     if (mAccelerometer)
     {
       const double *values = mAccelerometer->getValues();

--- a/webots_ros2_driver/src/plugins/static/Ros2Camera.cpp
+++ b/webots_ros2_driver/src/plugins/static/Ros2Camera.cpp
@@ -40,7 +40,7 @@ namespace webots_ros2_driver
     cameraInfoQos.transient_local();
     cameraInfoQos.keep_last(1);
     mCameraInfoPublisher = mNode->create_publisher<sensor_msgs::msg::CameraInfo>(mTopicName + "/camera_info", cameraInfoQos);
-    mCameraInfoMessage.header.stamp = rclcpp::Clock().now();
+    mCameraInfoMessage.header.stamp = mNode->get_clock()->now();
     mCameraInfoMessage.header.frame_id = mFrameName;
     mCameraInfoMessage.height = mCamera->getHeight();
     mCameraInfoMessage.width = mCamera->getWidth();
@@ -106,7 +106,7 @@ namespace webots_ros2_driver
     auto image = mCamera->getImage();
     if (image)
     {
-      mImageMessage.header.stamp = rclcpp::Clock().now();
+      mImageMessage.header.stamp = mNode->get_clock()->now();
       memcpy(mImageMessage.data.data(), image, mImageMessage.data.size());
       mImagePublisher->publish(mImageMessage);
     }
@@ -118,8 +118,8 @@ namespace webots_ros2_driver
       return;
 
     auto objects = mCamera->getRecognitionObjects();
-    mRecogntionMessage.header.stamp = rclcpp::Clock().now();
-    mWebotsRecognitionMessage.header.stamp = rclcpp::Clock().now();
+    mRecogntionMessage.header.stamp = mNode->get_clock()->now();
+    mWebotsRecognitionMessage.header.stamp = mNode->get_clock()->now();
 
     for (size_t i = 0; i < mCamera->getRecognitionNumberOfObjects(); i++)
     {

--- a/webots_ros2_driver/src/plugins/static/Ros2DistanceSensor.cpp
+++ b/webots_ros2_driver/src/plugins/static/Ros2DistanceSensor.cpp
@@ -61,7 +61,7 @@ namespace webots_ros2_driver
 
   void Ros2DistanceSensor::publishRange()
   {
-    mMessage.header.stamp = rclcpp::Clock().now();
+    mMessage.header.stamp = mNode->get_clock()->now();
     mMessage.range = interpolateLookupTable(mDistanceSensor->getValue(), mLookupTable);
     mPublisher->publish(mMessage);
   }

--- a/webots_ros2_driver/src/plugins/static/Ros2GPS.cpp
+++ b/webots_ros2_driver/src/plugins/static/Ros2GPS.cpp
@@ -74,7 +74,7 @@ namespace webots_ros2_driver
 
   void Ros2GPS::pubishPoint()
   {
-    mPointMessage.header.stamp = rclcpp::Clock().now();
+    mPointMessage.header.stamp = mNode->get_clock()->now();
     const double *values = mGPS->getValues();
     mPointMessage.point.x = values[0];
     mPointMessage.point.y = values[1];
@@ -84,7 +84,7 @@ namespace webots_ros2_driver
 
   void Ros2GPS::publishGPS()
   {
-    mGPSMessage.header.stamp = rclcpp::Clock().now();
+    mGPSMessage.header.stamp = mNode->get_clock()->now();
     const double *values = mGPS->getValues();
     mGPSMessage.latitude = values[0];
     mGPSMessage.longitude = values[1];

--- a/webots_ros2_driver/src/plugins/static/Ros2Lidar.cpp
+++ b/webots_ros2_driver/src/plugins/static/Ros2Lidar.cpp
@@ -111,7 +111,7 @@ namespace webots_ros2_driver
     auto data = mLidar->getPointCloud();
     if (data)
     {
-      mPointCloudMessage.header.stamp = rclcpp::Clock().now();
+      mPointCloudMessage.header.stamp = mNode->get_clock()->now();
 
       mPointCloudMessage.width = mLidar->getNumberOfPoints();
       mPointCloudMessage.row_step = 20 * mLidar->getNumberOfPoints();
@@ -129,7 +129,7 @@ namespace webots_ros2_driver
     if (rangeImage)
     {
       memcpy(mLaserMessage.ranges.data(), rangeImage, mLaserMessage.ranges.size() * sizeof(float));
-      mLaserMessage.header.stamp = rclcpp::Clock().now();
+      mLaserMessage.header.stamp = mNode->get_clock()->now();
       mLaserPublisher->publish(mLaserMessage);
     }
   }

--- a/webots_ros2_driver/src/plugins/static/Ros2LightSensor.cpp
+++ b/webots_ros2_driver/src/plugins/static/Ros2LightSensor.cpp
@@ -60,7 +60,7 @@ namespace webots_ros2_driver
   void Ros2LightSensor::publishValue()
   {
     const double value = mLightSensor->getValue();
-    mMessage.header.stamp = rclcpp::Clock().now();
+    mMessage.header.stamp = mNode->get_clock()->now();
     mMessage.illuminance = interpolateLookupTable(value, mLookupTable);
     mMessage.variance = findVariance(value);
     mPublisher->publish(mMessage);

--- a/webots_ros2_driver/src/plugins/static/Ros2RangeFinder.cpp
+++ b/webots_ros2_driver/src/plugins/static/Ros2RangeFinder.cpp
@@ -43,7 +43,7 @@ namespace webots_ros2_driver
     cameraInfoQos.transient_local();
     cameraInfoQos.keep_last(1);
     mCameraInfoPublisher = mNode->create_publisher<sensor_msgs::msg::CameraInfo>(mTopicName + "/camera_info", cameraInfoQos);
-    mCameraInfoMessage.header.stamp = rclcpp::Clock().now();
+    mCameraInfoMessage.header.stamp = mNode->get_clock()->now();
     mCameraInfoMessage.header.frame_id = mFrameName;
     mCameraInfoMessage.height = mRangeFinder->getHeight();
     mCameraInfoMessage.width = mRangeFinder->getWidth();
@@ -90,7 +90,7 @@ namespace webots_ros2_driver
     auto image = mRangeFinder->getRangeImage();
     if (image)
     {
-      mImageMessage.header.stamp = rclcpp::Clock().now();
+      mImageMessage.header.stamp = mNode->get_clock()->now();
       memcpy(mImageMessage.data.data(), image, mImageMessage.data.size());
       mImagePublisher->publish(mImageMessage);
     }

--- a/webots_ros2_turtlebot/launch/robot_launch.py
+++ b/webots_ros2_turtlebot/launch/robot_launch.py
@@ -33,6 +33,7 @@ def generate_launch_description():
     world = LaunchConfiguration('world')
     robot_description = pathlib.Path(os.path.join(package_dir, 'resource', 'turtlebot_webots.urdf')).read_text()
     ros2_control_params = os.path.join(package_dir, 'resource', 'ros2control.yml')
+    use_sim_time = LaunchConfiguration('use_sim_time', default=True)
 
     webots = WebotsLauncher(
         world=PathJoinSubstitution([package_dir, 'worlds', world])
@@ -63,7 +64,8 @@ def generate_launch_description():
         executable='driver',
         output='screen',
         parameters=[
-            {'robot_description': robot_description},
+            {'robot_description': robot_description,
+             'use_sim_time': use_sim_time},
             ros2_control_params
         ],
         remappings=[


### PR DESCRIPTION
**Description**
If `use_sim_time = True` the lidar scan message timestamp should use sim time.

**Related Issues**
This pull-request fixes issue #260

**Affected Packages**
List of affected packages:
  - webots_ros2_driver

**Additional context**
Some more devices uses the same old behaviour (e.g. Ros2GPS). I don't know if i should fix this too.
I added the launch file changes too. Should i remove them from the PR?
