### PR TITLE
Fix Rolling warnings and `ament_python_install_package`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         ROS_REPO: [main, testing]
-        ROS_DISTRO: [foxy]
+        ROS_DISTRO: [foxy, rolling]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/webots_ros2/setup.cfg
+++ b/webots_ros2/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/webots_ros2
+script_dir=$base/lib/webots_ros2
 [install]
-install-scripts=$base/lib/webots_ros2
+install_scripts=$base/lib/webots_ros2

--- a/webots_ros2_abb/setup.cfg
+++ b/webots_ros2_abb/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/webots_ros2_abb
+script_dir=$base/lib/webots_ros2_abb
 [install]
-install-scripts=$base/lib/webots_ros2_abb
+install_scripts=$base/lib/webots_ros2_abb

--- a/webots_ros2_core/setup.cfg
+++ b/webots_ros2_core/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/webots_ros2_core
+script_dir=$base/lib/webots_ros2_core
 [install]
-install-scripts=$base/lib/webots_ros2_core
+install_scripts=$base/lib/webots_ros2_core

--- a/webots_ros2_demos/setup.cfg
+++ b/webots_ros2_demos/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/webots_ros2_demos
+script_dir=$base/lib/webots_ros2_demos
 [install]
-install-scripts=$base/lib/webots_ros2_demos
+install_scripts=$base/lib/webots_ros2_demos

--- a/webots_ros2_driver/CMakeLists.txt
+++ b/webots_ros2_driver/CMakeLists.txt
@@ -67,7 +67,7 @@ else()
   )
 endif()
 
-ament_python_install_package(${PROJECT_NAME}/webots
+ament_python_install_package(${PROJECT_NAME}_webots
   PACKAGE_DIR ${WEBOTS_LIB_BASE}/python38)
 
 add_executable(driver
@@ -158,13 +158,13 @@ if (MSVC OR MSYS OR MINGW OR WIN32)
   # Windows requires the C++ library to be placed with the Python module
   install(
     FILES "${WEBOTS_LIB_BASE}/${CMAKE_SHARED_LIBRARY_PREFIX}CppController${CMAKE_SHARED_LIBRARY_SUFFIX}"
-    DESTINATION "${PYTHON_INSTALL_DIR}/${PROJECT_NAME}/webots/"
+    DESTINATION "${PYTHON_INSTALL_DIR}/${PROJECT_NAME}_webots/"
   )
 else()
   install(
     DIRECTORY ${WEBOTS_LIB_BASE}/
     DESTINATION lib
-    FILES_MATCHING
+    PATTERN "python*" EXCLUDE
     PATTERN "*Controller*"
     PATTERN "*CppController*"
     PATTERN "*car*"

--- a/webots_ros2_driver/src/PythonPlugin.cpp
+++ b/webots_ros2_driver/src/PythonPlugin.cpp
@@ -29,7 +29,7 @@ namespace webots_ros2_driver
 
         PyObject *pyWebotsExtraModuleSource = Py_CompileString(
             R"EOT(
-from webots_ros2_driver.webots.controller import Supervisor
+from webots_ros2_driver_webots.controller import Supervisor
 
 class WebotsNode:
     def __init__(self):

--- a/webots_ros2_epuck/setup.cfg
+++ b/webots_ros2_epuck/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/webots_ros2_epuck
+script_dir=$base/lib/webots_ros2_epuck
 [install]
-install-scripts=$base/lib/webots_ros2_epuck
+install_scripts=$base/lib/webots_ros2_epuck

--- a/webots_ros2_examples/setup.cfg
+++ b/webots_ros2_examples/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/webots_ros2_examples
+script_dir=$base/lib/webots_ros2_examples
 [install]
-install-scripts=$base/lib/webots_ros2_examples
+install_scripts=$base/lib/webots_ros2_examples

--- a/webots_ros2_importer/setup.cfg
+++ b/webots_ros2_importer/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/webots_ros2_importer
+script_dir=$base/lib/webots_ros2_importer
 [install]
-install-scripts=$base/lib/webots_ros2_importer
+install_scripts=$base/lib/webots_ros2_importer

--- a/webots_ros2_mavic/setup.cfg
+++ b/webots_ros2_mavic/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/webots_ros2_mavic
+script_dir=$base/lib/webots_ros2_mavic
 [install]
-install-scripts=$base/lib/webots_ros2_mavic
+install_scripts=$base/lib/webots_ros2_mavic

--- a/webots_ros2_tesla/setup.cfg
+++ b/webots_ros2_tesla/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/webots_ros2_tesla
+script_dir=$base/lib/webots_ros2_tesla
 [install]
-install-scripts=$base/lib/webots_ros2_tesla
+install_scripts=$base/lib/webots_ros2_tesla

--- a/webots_ros2_tiago/setup.cfg
+++ b/webots_ros2_tiago/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/webots_ros2_tiago
+script_dir=$base/lib/webots_ros2_tiago
 [install]
-install-scripts=$base/lib/webots_ros2_tiago
+install_scripts=$base/lib/webots_ros2_tiago

--- a/webots_ros2_turtlebot/setup.cfg
+++ b/webots_ros2_turtlebot/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/webots_ros2_turtlebot
+script_dir=$base/lib/webots_ros2_turtlebot
 [install]
-install-scripts=$base/lib/webots_ros2_turtlebot
+install_scripts=$base/lib/webots_ros2_turtlebot

--- a/webots_ros2_turtlebot/webots_ros2_turtlebot/plugin_example.py
+++ b/webots_ros2_turtlebot/webots_ros2_turtlebot/plugin_example.py
@@ -14,7 +14,7 @@
 
 """A simple dummy plugin that demonstrates the usage of Python plugins."""
 
-from webots_ros2_driver.webots.controller import Node
+from webots_ros2_driver_webots.controller import Node
 from std_msgs.msg import Float32
 import rclpy
 import rclpy.node

--- a/webots_ros2_tutorials/setup.cfg
+++ b/webots_ros2_tutorials/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/webots_ros2_tutorials
+script_dir=$base/lib/webots_ros2_tutorials
 [install]
-install-scripts=$base/lib/webots_ros2_tutorials
+install_scripts=$base/lib/webots_ros2_tutorials

--- a/webots_ros2_universal_robot/setup.cfg
+++ b/webots_ros2_universal_robot/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/webots_ros2_universal_robot
+script_dir=$base/lib/webots_ros2_universal_robot
 [install]
-install-scripts=$base/lib/webots_ros2_universal_robot
+install_scripts=$base/lib/webots_ros2_universal_robot

--- a/webots_ros2_ur_e_description/setup.cfg
+++ b/webots_ros2_ur_e_description/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/webots_ros2_ur_e_description
+script_dir=$base/lib/webots_ros2_ur_e_description
 [install]
-install-scripts=$base/lib/webots_ros2_ur_e_description
+install_scripts=$base/lib/webots_ros2_ur_e_description


### PR DESCRIPTION
The PR fixes warnings from the build farm:
```
/usr/local/lib/python3.8/dist-packages/setuptools/dist.py:697: UserWarning: Usage of dash-separated 'script-dir' will not be supported in future versions. Please use the underscore name 'script_dir' instead
/usr/local/lib/python3.8/dist-packages/setuptools/dist.py:697: UserWarning: Usage of dash-separated 'install-scripts' will not be supported in future versions. Please use the underscore name 'install_scripts' instead
```
- https://build.ros2.org/job/Rdev__webots_ros2__ubuntu_focal_amd64/42/console

Also, the `ament_python_install_package` seems to doesn't support creating subpackages. It is something it was working perfectly in Foxy, but Rolling breaks the behavior (the issue is reported). As a solution, we store the Python libController to `webots_ros2_driver_webots`:
```py
from webots_ros2_driver_webots.controller import Node
```
It looks ugly but it works