### PR TITLE
Fix URDF importer dependencies

### DIFF
--- a/webots_ros2_importer/package.xml
+++ b/webots_ros2_importer/package.xml
@@ -22,7 +22,7 @@
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>
   <test_depend>python3-pycodestyle</test_depend>
-  <test_depend>python3-pillow</test_depend>
+  <test_depend>python3-pil</test_depend>
   <test_depend>python3-numpy</test_depend>
   <test_depend>python3-pytest</test_depend>
 


### PR DESCRIPTION
This PR tries to resolve #218

According to [urdf2webots/setup.py](https://github.com/cyberbotics/urdf2webots/blob/1d4ddbe3f0dc9b5a65edeed3249d91d5bf54b052/setup.py#L25) we need the `pillow` package.

There is some weird relationship between `pil` and `pillow` (fork of `pil`). It seems in some distros they tried to preserve the backward compatibility, so the old name (`pil`) is used for the `pillow` package.

Anyways, the test is passing and seems the `pil` package is enough (we don't need `imaging`):
https://github.com/ros/rosdistro/blob/cb9a97220ceb196de206fab675309a6cb2138572/rosdep/python.yaml#L7007-L7024