### PR TITLE
Revert `robot_state_publisher` check

### DIFF
--- a/webots_ros2_driver/src/WebotsNode.cpp
+++ b/webots_ros2_driver/src/WebotsNode.cpp
@@ -112,18 +112,8 @@ namespace webots_ros2_driver
 
   void WebotsNode::init()
   {
-    const std::vector<std::string> nodeNames = this->get_node_names();
-    for (int k = 0; k < nodeNames.size(); ++k)
-    {
-      if (nodeNames[k] == "/robot_state_publisher")
-      {
-        setAnotherNodeParameter("robot_state_publisher", "robot_description", mRobot->getUrdf());
-        break;
-      }
-      if (k == nodeNames.size() - 1) 
-        RCLCPP_INFO(get_logger(), "There is no the `robot_state_publisher` node, the `robot_description` parameter is not set.");
-    }
-    
+    setAnotherNodeParameter("robot_state_publisher", "robot_description", mRobot->getUrdf());
+
     mStep = mRobot->getBasicTimeStep();
     mTimer = this->create_wall_timer(std::chrono::milliseconds(1), std::bind(&WebotsNode::timerCallback, this));
 


### PR DESCRIPTION
This PR reverts changes made in #283.

The `get_node_names` never returns the `robot_state_publisher` node on Linux. @dzywater we have to find another way to check whether the `robot_state_publisher` node exists.