### PR TITLE
Correction for Rolling CI testing failling due to change in ros2control (base_interface)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         ROS_REPO: [main, testing]
-        ROS_DISTRO: [foxy, rolling]
+        ROS_DISTRO: [foxy, galactic, rolling]
     runs-on: ubuntu-latest
     env:
       AFTER_INIT: ./scripts/ci_after_init.bash ${ROS_DISTRO} ${ROS_REPO}

--- a/webots_ros2_control/CMakeLists.txt
+++ b/webots_ros2_control/CMakeLists.txt
@@ -1,6 +1,17 @@
 cmake_minimum_required(VERSION 3.5)
 project(webots_ros2_control)
 
+# Check which ROS distribution is used, ros2control depends of that
+if($ENV{ROS_DISTRO} MATCHES "foxy")
+  add_compile_definitions(FOXY)
+elseif($ENV{ROS_DISTRO} MATCHES "rolling")
+  add_compile_definitions(ROLLING)
+endif()
+
+if($ENV{ROS_REPO} MATCHES "main")
+  add_compile_definitions(MAIN)
+endif()
+
 # Default to C99
 if(NOT CMAKE_C_STANDARD)
   set(CMAKE_C_STANDARD 99)

--- a/webots_ros2_control/CMakeLists.txt
+++ b/webots_ros2_control/CMakeLists.txt
@@ -4,12 +4,6 @@ project(webots_ros2_control)
 # Check which ROS distribution is used, ros2control depends of that
 if($ENV{ROS_DISTRO} MATCHES "foxy")
   add_compile_definitions(FOXY)
-elseif($ENV{ROS_DISTRO} MATCHES "rolling")
-  add_compile_definitions(ROLLING)
-endif()
-
-if($ENV{ROS_REPO} MATCHES "main")
-  add_compile_definitions(MAIN)
 endif()
 
 # Default to C99

--- a/webots_ros2_control/include/webots_ros2_control/Ros2Control.hpp
+++ b/webots_ros2_control/include/webots_ros2_control/Ros2Control.hpp
@@ -20,12 +20,15 @@
 #include <vector>
 #include <thread>
 
+#if ROS_DISTRO == 'foxy' || (ROS_DISTRO == 'rolling' && ROS_REPO == 'main')
 #include "hardware_interface/base_interface.hpp"
+#include "hardware_interface/types/hardware_interface_status_values.hpp"
+#endif
+
 #include "hardware_interface/system_interface.hpp"
 #include "hardware_interface/handle.hpp"
 #include "hardware_interface/hardware_info.hpp"
 #include "hardware_interface/types/hardware_interface_return_values.hpp"
-#include "hardware_interface/types/hardware_interface_status_values.hpp"
 #include "controller_manager/controller_manager.hpp"
 #include "rclcpp/macros.hpp"
 #include "webots_ros2_driver/PluginInterface.hpp"

--- a/webots_ros2_control/include/webots_ros2_control/Ros2Control.hpp
+++ b/webots_ros2_control/include/webots_ros2_control/Ros2Control.hpp
@@ -20,9 +20,9 @@
 #include <vector>
 #include <thread>
 
-#if ROS_DISTRO == 'foxy' || (ROS_DISTRO == 'rolling' && ROS_REPO == 'main')
-#include "hardware_interface/base_interface.hpp"
-#include "hardware_interface/types/hardware_interface_status_values.hpp"
+#if FOXY || (ROLLING && MAIN)
+  #include "hardware_interface/base_interface.hpp"
+  #include "hardware_interface/types/hardware_interface_status_values.hpp"
 #endif
 
 #include "hardware_interface/system_interface.hpp"

--- a/webots_ros2_control/include/webots_ros2_control/Ros2Control.hpp
+++ b/webots_ros2_control/include/webots_ros2_control/Ros2Control.hpp
@@ -20,7 +20,7 @@
 #include <vector>
 #include <thread>
 
-#if FOXY || (ROLLING && MAIN)
+#if FOXY
   #include "hardware_interface/base_interface.hpp"
   #include "hardware_interface/types/hardware_interface_status_values.hpp"
 #endif

--- a/webots_ros2_control/include/webots_ros2_control/Ros2ControlSystem.hpp
+++ b/webots_ros2_control/include/webots_ros2_control/Ros2ControlSystem.hpp
@@ -19,7 +19,7 @@
 #include <string>
 #include <vector>
 
-#if ROS_DISTRO == 'foxy' || (ROS_DISTRO == 'rolling' && ROS_REPO == 'main')
+#if FOXY == 1 || (ROS_DISTRO == 1 && ROS_REPO == 1)
   #include "hardware_interface/base_interface.hpp"
   #include "hardware_interface/types/hardware_interface_status_values.hpp"
 #endif
@@ -58,7 +58,7 @@ namespace webots_ros2_control
   public:
     void init(webots_ros2_driver::WebotsNode *node, const hardware_interface::HardwareInfo &info) override;
 
-    #if ROS_DISTRO == 'foxy' || (ROS_DISTRO == 'rolling' && ROS_REPO == 'main')
+    #if FOXY || (ROLLING && MAIN)
       hardware_interface::return_type configure(const hardware_interface::HardwareInfo &info) override;
       hardware_interface::return_type start() override;
       hardware_interface::return_type stop() override;

--- a/webots_ros2_control/include/webots_ros2_control/Ros2ControlSystem.hpp
+++ b/webots_ros2_control/include/webots_ros2_control/Ros2ControlSystem.hpp
@@ -19,12 +19,15 @@
 #include <string>
 #include <vector>
 
-#include "hardware_interface/base_interface.hpp"
+#if ROS_DISTRO == 'foxy' || (ROS_DISTRO == 'rolling' && ROS_REPO == 'main')
+  #include "hardware_interface/base_interface.hpp"
+  #include "hardware_interface/types/hardware_interface_status_values.hpp"
+#endif
+
 #include "hardware_interface/system_interface.hpp"
 #include "hardware_interface/handle.hpp"
 #include "hardware_interface/hardware_info.hpp"
 #include "hardware_interface/types/hardware_interface_return_values.hpp"
-#include "hardware_interface/types/hardware_interface_status_values.hpp"
 #include "rclcpp/macros.hpp"
 #include "webots_ros2_driver/PluginInterface.hpp"
 #include "webots_ros2_driver/WebotsNode.hpp"
@@ -55,11 +58,18 @@ namespace webots_ros2_control
   public:
     void init(webots_ros2_driver::WebotsNode *node, const hardware_interface::HardwareInfo &info) override;
 
-    hardware_interface::return_type configure(const hardware_interface::HardwareInfo &info) override;
+    #if ROS_DISTRO == 'foxy' || (ROS_DISTRO == 'rolling' && ROS_REPO == 'main')
+      hardware_interface::return_type configure(const hardware_interface::HardwareInfo &info) override;
+      hardware_interface::return_type start() override;
+      hardware_interface::return_type stop() override;
+    #else
+      CallbackReturn on_init(const hardware_interface::HardwareInfo &info) override;
+      CallbackReturn on_activate(const rclcpp_lifecycle::State & /*previous_state*/) override;
+      CallbackReturn on_deactivate(const rclcpp_lifecycle::State & /*previous_state*/) override;
+    #endif
+
     std::vector<hardware_interface::StateInterface> export_state_interfaces() override;
     std::vector<hardware_interface::CommandInterface> export_command_interfaces() override;
-    hardware_interface::return_type start() override;
-    hardware_interface::return_type stop() override;
     hardware_interface::return_type read() override;
     hardware_interface::return_type write() override;
 

--- a/webots_ros2_control/include/webots_ros2_control/Ros2ControlSystem.hpp
+++ b/webots_ros2_control/include/webots_ros2_control/Ros2ControlSystem.hpp
@@ -19,7 +19,7 @@
 #include <string>
 #include <vector>
 
-#if FOXY == 1 || (ROS_DISTRO == 1 && ROS_REPO == 1)
+#if FOXY || (ROLLING && MAIN)
   #include "hardware_interface/base_interface.hpp"
   #include "hardware_interface/types/hardware_interface_status_values.hpp"
 #endif

--- a/webots_ros2_control/include/webots_ros2_control/Ros2ControlSystem.hpp
+++ b/webots_ros2_control/include/webots_ros2_control/Ros2ControlSystem.hpp
@@ -19,7 +19,7 @@
 #include <string>
 #include <vector>
 
-#if FOXY || (ROLLING && MAIN)
+#if FOXY
   #include "hardware_interface/base_interface.hpp"
   #include "hardware_interface/types/hardware_interface_status_values.hpp"
 #endif
@@ -58,7 +58,7 @@ namespace webots_ros2_control
   public:
     void init(webots_ros2_driver::WebotsNode *node, const hardware_interface::HardwareInfo &info) override;
 
-    #if FOXY || (ROLLING && MAIN)
+    #if FOXY
       hardware_interface::return_type configure(const hardware_interface::HardwareInfo &info) override;
       hardware_interface::return_type start() override;
       hardware_interface::return_type stop() override;

--- a/webots_ros2_control/include/webots_ros2_control/Ros2ControlSystemInterface.hpp
+++ b/webots_ros2_control/include/webots_ros2_control/Ros2ControlSystemInterface.hpp
@@ -19,7 +19,7 @@
 #include <string>
 #include <vector>
 
-#if FOXY || (ROLLING && MAIN)
+#if FOXY
   #include "hardware_interface/base_interface.hpp"
   #include "hardware_interface/types/hardware_interface_status_values.hpp"
 #endif
@@ -34,7 +34,7 @@
 
 namespace webots_ros2_control
 {
-  #if FOXY || (ROLLING && MAIN)
+  #if FOXY
     class Ros2ControlSystemInterface : public hardware_interface::BaseInterface<hardware_interface::SystemInterface>
     {
     public:

--- a/webots_ros2_control/include/webots_ros2_control/Ros2ControlSystemInterface.hpp
+++ b/webots_ros2_control/include/webots_ros2_control/Ros2ControlSystemInterface.hpp
@@ -19,19 +19,27 @@
 #include <string>
 #include <vector>
 
-#include "hardware_interface/base_interface.hpp"
+#if ROS_DISTRO == 'foxy' || (ROS_DISTRO == 'rolling' && ROS_REPO == 'main')
+  #include "hardware_interface/base_interface.hpp"
+  #include "hardware_interface/types/hardware_interface_status_values.hpp"
+#endif
+
 #include "hardware_interface/system_interface.hpp"
 #include "hardware_interface/handle.hpp"
 #include "hardware_interface/hardware_info.hpp"
 #include "hardware_interface/types/hardware_interface_return_values.hpp"
-#include "hardware_interface/types/hardware_interface_status_values.hpp"
 #include "webots_ros2_driver/PluginInterface.hpp"
 #include <webots/Supervisor.hpp>
 #include "webots_ros2_driver/WebotsNode.hpp"
 
 namespace webots_ros2_control
 {
-  class Ros2ControlSystemInterface : public hardware_interface::BaseInterface<hardware_interface::SystemInterface>
+  #if ROS_DISTRO == 'foxy' || (ROS_DISTRO == 'rolling' && ROS_REPO == 'main')
+    class Ros2ControlSystemInterface : public hardware_interface::BaseInterface<hardware_interface::SystemInterface>
+  #else
+    class Ros2ControlSystemInterface : public hardware_interface::SystemInterface
+  #endif
+  class Ros2ControlSystemInterface : public hardware_interface::SystemInterface
   {
   public:
     virtual void init(webots_ros2_driver::WebotsNode *node, const hardware_interface::HardwareInfo &info) = 0;

--- a/webots_ros2_control/include/webots_ros2_control/Ros2ControlSystemInterface.hpp
+++ b/webots_ros2_control/include/webots_ros2_control/Ros2ControlSystemInterface.hpp
@@ -19,7 +19,7 @@
 #include <string>
 #include <vector>
 
-#if ROS_DISTRO == 'foxy' || (ROS_DISTRO == 'rolling' && ROS_REPO == 'main')
+#if FOXY || (ROLLING && MAIN)
   #include "hardware_interface/base_interface.hpp"
   #include "hardware_interface/types/hardware_interface_status_values.hpp"
 #endif
@@ -34,16 +34,20 @@
 
 namespace webots_ros2_control
 {
-  #if ROS_DISTRO == 'foxy' || (ROS_DISTRO == 'rolling' && ROS_REPO == 'main')
+  #if FOXY || (ROLLING && MAIN)
     class Ros2ControlSystemInterface : public hardware_interface::BaseInterface<hardware_interface::SystemInterface>
+    {
+    public:
+      virtual void init(webots_ros2_driver::WebotsNode *node, const hardware_interface::HardwareInfo &info) = 0;
+    };
   #else
     class Ros2ControlSystemInterface : public hardware_interface::SystemInterface
+    {
+    public:
+      virtual void init(webots_ros2_driver::WebotsNode *node, const hardware_interface::HardwareInfo &info) = 0;
+    };
   #endif
-  class Ros2ControlSystemInterface : public hardware_interface::SystemInterface
-  {
-  public:
-    virtual void init(webots_ros2_driver::WebotsNode *node, const hardware_interface::HardwareInfo &info) = 0;
-  };
+  
 }
 
 #endif

--- a/webots_ros2_control/src/Ros2Control.cpp
+++ b/webots_ros2_control/src/Ros2Control.cpp
@@ -33,7 +33,7 @@ namespace webots_ros2_control
   void Ros2Control::step()
   {
     mControllerManager->read();
-    #if FOXY || (ROLLING && MAIN)
+    #if FOXY
       mControllerManager->update();
     #else
       rclcpp::Duration dt = rclcpp::Duration::from_nanoseconds(RCL_MS_TO_NS(mNode->robot()->getBasicTimeStep()));
@@ -77,7 +77,7 @@ namespace webots_ros2_control
       auto webotsSystem = std::unique_ptr<webots_ros2_control::Ros2ControlSystemInterface>(
           mHardwareLoader->createUnmanagedInstance(hardwareType));
       webotsSystem->init(mNode, controlHardware[i]);
-      #if FOXY || (ROLLING && MAIN)
+      #if FOXY
         resourceManager->import_component(std::move(webotsSystem));
       #else
         resourceManager->import_component(std::move(webotsSystem), controlHardware[i]);

--- a/webots_ros2_control/src/Ros2Control.cpp
+++ b/webots_ros2_control/src/Ros2Control.cpp
@@ -33,7 +33,12 @@ namespace webots_ros2_control
   void Ros2Control::step()
   {
     mControllerManager->read();
-    mControllerManager->update();
+    #if ROS_DISTRO == 'foxy' || (ROS_DISTRO == 'rolling' && ROS_REPO == 'main')
+      mControllerManager->update();
+    #else
+      auto dt = rclcpp::Duration::from_nanoseconds(mNode->robot()->getBasicTimeStep()*1e6);
+      mControllerManager->update(mNode->get_clock()->now(), dt);
+    #endif
     mControllerManager->write();
   }
 

--- a/webots_ros2_control/src/Ros2Control.cpp
+++ b/webots_ros2_control/src/Ros2Control.cpp
@@ -36,7 +36,7 @@ namespace webots_ros2_control
     #if FOXY || (ROLLING && MAIN)
       mControllerManager->update();
     #else
-      auto dt = rclcpp::Duration::from_nanoseconds(RCL_S_TO_NS(mNode->robot()->getBasicTimeStep()));
+      rclcpp::Duration dt = rclcpp::Duration::from_nanoseconds(RCL_MS_TO_NS(mNode->robot()->getBasicTimeStep()));
       mControllerManager->update(mNode->get_clock()->now(), dt);
     #endif
     mControllerManager->write();

--- a/webots_ros2_control/src/Ros2Control.cpp
+++ b/webots_ros2_control/src/Ros2Control.cpp
@@ -36,7 +36,7 @@ namespace webots_ros2_control
     #if FOXY || (ROLLING && MAIN)
       mControllerManager->update();
     #else
-      auto dt = rclcpp::Duration::from_nanoseconds(mNode->robot()->getBasicTimeStep()*1e6);
+      auto dt = rclcpp::Duration::from_nanoseconds(mNode->robot()->getBasicTimeStep()*(int)1e6);
       mControllerManager->update(mNode->get_clock()->now(), dt);
     #endif
     mControllerManager->write();

--- a/webots_ros2_control/src/Ros2Control.cpp
+++ b/webots_ros2_control/src/Ros2Control.cpp
@@ -77,7 +77,11 @@ namespace webots_ros2_control
       auto webotsSystem = std::unique_ptr<webots_ros2_control::Ros2ControlSystemInterface>(
           mHardwareLoader->createUnmanagedInstance(hardwareType));
       webotsSystem->init(mNode, controlHardware[i]);
-      resourceManager->import_component(std::move(webotsSystem));
+      #if FOXY || (ROLLING && MAIN)
+        resourceManager->import_component(std::move(webotsSystem));
+      #else
+        resourceManager->import_component(std::move(webotsSystem), controlHardware[i]);
+      #endif
     }
 
     // Controller Manager

--- a/webots_ros2_control/src/Ros2Control.cpp
+++ b/webots_ros2_control/src/Ros2Control.cpp
@@ -36,7 +36,7 @@ namespace webots_ros2_control
     #if FOXY || (ROLLING && MAIN)
       mControllerManager->update();
     #else
-      auto dt = rclcpp::Duration::from_nanoseconds(mNode->robot()->getBasicTimeStep()*(int)1e6);
+      auto dt = rclcpp::Duration::from_nanoseconds(RCL_S_TO_NS(static_cast<int64_t>(mNode->robot()->getBasicTimeStep())));
       mControllerManager->update(mNode->get_clock()->now(), dt);
     #endif
     mControllerManager->write();

--- a/webots_ros2_control/src/Ros2Control.cpp
+++ b/webots_ros2_control/src/Ros2Control.cpp
@@ -36,7 +36,7 @@ namespace webots_ros2_control
     #if FOXY || (ROLLING && MAIN)
       mControllerManager->update();
     #else
-      auto dt = rclcpp::Duration::from_nanoseconds(RCL_S_TO_NS(static_cast<int64_t>(mNode->robot()->getBasicTimeStep())));
+      auto dt = rclcpp::Duration::from_nanoseconds(RCL_S_TO_NS(mNode->robot()->getBasicTimeStep()));
       mControllerManager->update(mNode->get_clock()->now(), dt);
     #endif
     mControllerManager->write();

--- a/webots_ros2_control/src/Ros2Control.cpp
+++ b/webots_ros2_control/src/Ros2Control.cpp
@@ -33,7 +33,7 @@ namespace webots_ros2_control
   void Ros2Control::step()
   {
     mControllerManager->read();
-    #if ROS_DISTRO == 'foxy' || (ROS_DISTRO == 'rolling' && ROS_REPO == 'main')
+    #if FOXY || (ROLLING && MAIN)
       mControllerManager->update();
     #else
       auto dt = rclcpp::Duration::from_nanoseconds(mNode->robot()->getBasicTimeStep()*1e6);

--- a/webots_ros2_control/src/Ros2ControlSystem.cpp
+++ b/webots_ros2_control/src/Ros2ControlSystem.cpp
@@ -72,7 +72,7 @@ namespace webots_ros2_control
     }
   }
 
-  #if ROS_DISTRO == 'foxy' || (ROS_DISTRO == 'rolling' && ROS_REPO == 'main')
+  #if FOXY || (ROLLING && MAIN)
     hardware_interface::return_type Ros2ControlSystem::configure(const hardware_interface::HardwareInfo &info)
     {
       if (configure_default(info) != hardware_interface::return_type::OK)
@@ -119,7 +119,7 @@ namespace webots_ros2_control
     return interfaces;
   }
 
-  #if ROS_DISTRO == 'foxy' || (ROS_DISTRO == 'rolling' && ROS_REPO == 'main')
+  #if FOXY || (ROLLING && MAIN)
     hardware_interface::return_type Ros2ControlSystem::start()
     {
       status_ = hardware_interface::status::STARTED;

--- a/webots_ros2_control/src/Ros2ControlSystem.cpp
+++ b/webots_ros2_control/src/Ros2ControlSystem.cpp
@@ -156,10 +156,13 @@ namespace webots_ros2_control
 
   hardware_interface::return_type Ros2ControlSystem::write()
   {
+    std::cout << " write \n";
     for (Joint &joint : mJoints)
     {
+      std::cout << " for joint \n";
       if (joint.motor)
       {
+        std::cout << " joint.motor \n";
         if (joint.controlPosition && !std::isnan(joint.positionCommand))
           joint.motor->setPosition(joint.positionCommand);
         if (joint.controlVelocity && !std::isnan(joint.velocityCommand))

--- a/webots_ros2_control/src/Ros2ControlSystem.cpp
+++ b/webots_ros2_control/src/Ros2ControlSystem.cpp
@@ -72,15 +72,26 @@ namespace webots_ros2_control
     }
   }
 
-  hardware_interface::return_type Ros2ControlSystem::configure(const hardware_interface::HardwareInfo &info)
-  {
-    if (configure_default(info) != hardware_interface::return_type::OK)
+  #if ROS_DISTRO == 'foxy' || (ROS_DISTRO == 'rolling' && ROS_REPO == 'main')
+    hardware_interface::return_type Ros2ControlSystem::configure(const hardware_interface::HardwareInfo &info)
     {
-      return hardware_interface::return_type::ERROR;
+      if (configure_default(info) != hardware_interface::return_type::OK)
+      {
+        return hardware_interface::return_type::ERROR;
+      }
+      status_ = hardware_interface::status::CONFIGURED;
+      return hardware_interface::return_type::OK;
     }
-    status_ = hardware_interface::status::CONFIGURED;
-    return hardware_interface::return_type::OK;
-  }
+  #else
+    CallbackReturn Ros2ControlSystem::on_init(const hardware_interface::HardwareInfo &info)
+    {
+      if (hardware_interface::SystemInterface::on_init(info) != CallbackReturn::SUCCESS)
+      {
+        return CallbackReturn::ERROR;
+      }
+      return CallbackReturn::SUCCESS;
+    }
+  #endif
 
   std::vector<hardware_interface::StateInterface> Ros2ControlSystem::export_state_interfaces()
   {
@@ -108,17 +119,29 @@ namespace webots_ros2_control
     return interfaces;
   }
 
-  hardware_interface::return_type Ros2ControlSystem::start()
-  {
-    status_ = hardware_interface::status::STARTED;
-    return hardware_interface::return_type::OK;
-  }
+  #if ROS_DISTRO == 'foxy' || (ROS_DISTRO == 'rolling' && ROS_REPO == 'main')
+    hardware_interface::return_type Ros2ControlSystem::start()
+    {
+      status_ = hardware_interface::status::STARTED;
+      return hardware_interface::return_type::OK;
+    }
 
-  hardware_interface::return_type Ros2ControlSystem::stop()
-  {
-    status_ = hardware_interface::status::STOPPED;
-    return hardware_interface::return_type::OK;
-  }
+    hardware_interface::return_type Ros2ControlSystem::stop()
+    {
+      status_ = hardware_interface::status::STOPPED;
+      return hardware_interface::return_type::OK;
+    }
+  #else
+    CallbackReturn Ros2ControlSystem::on_activate(const rclcpp_lifecycle::State & /*previous_state*/)
+    {
+      return CallbackReturn::SUCCESS;
+    }
+
+    CallbackReturn Ros2ControlSystem::on_deactivate(const rclcpp_lifecycle::State & /*previous_state*/)
+    {
+      return CallbackReturn::SUCCESS;
+    }
+  #endif
 
   hardware_interface::return_type Ros2ControlSystem::read()
   {

--- a/webots_ros2_control/src/Ros2ControlSystem.cpp
+++ b/webots_ros2_control/src/Ros2ControlSystem.cpp
@@ -72,7 +72,7 @@ namespace webots_ros2_control
     }
   }
 
-  #if FOXY || (ROLLING && MAIN)
+  #if FOXY
     hardware_interface::return_type Ros2ControlSystem::configure(const hardware_interface::HardwareInfo &info)
     {
       if (configure_default(info) != hardware_interface::return_type::OK)
@@ -119,7 +119,7 @@ namespace webots_ros2_control
     return interfaces;
   }
 
-  #if FOXY || (ROLLING && MAIN)
+  #if FOXY
     hardware_interface::return_type Ros2ControlSystem::start()
     {
       status_ = hardware_interface::status::STARTED;

--- a/webots_ros2_control/src/Ros2ControlSystem.cpp
+++ b/webots_ros2_control/src/Ros2ControlSystem.cpp
@@ -156,13 +156,10 @@ namespace webots_ros2_control
 
   hardware_interface::return_type Ros2ControlSystem::write()
   {
-    std::cout << " write \n";
     for (Joint &joint : mJoints)
     {
-      std::cout << " for joint \n";
       if (joint.motor)
       {
-        std::cout << " joint.motor \n";
         if (joint.controlPosition && !std::isnan(joint.positionCommand))
           joint.motor->setPosition(joint.positionCommand);
         if (joint.controlVelocity && !std::isnan(joint.velocityCommand))

--- a/webots_ros2_tesla/webots_ros2_tesla/lane_follower.py
+++ b/webots_ros2_tesla/webots_ros2_tesla/lane_follower.py
@@ -36,7 +36,7 @@ class LaneFollower(Node):
 
         qos_camera_data = qos_profile_sensor_data
         # In case ROS_DISTRO is Rolling the QoSReliabilityPolicy is strict.
-        if ('ROS_DISTRO' in os.environ and os.environ['ROS_DISTRO'] == 'rolling'):
+        if ('ROS_DISTRO' in os.environ and (os.environ['ROS_DISTRO'] == 'rolling' or os.environ['ROS_DISTRO'] == 'galactic')):
             qos_camera_data.reliability = QoSReliabilityPolicy.RELIABLE
         self.create_subscription(Image, 'vehicle/camera', self.__on_camera_image, qos_camera_data)
 

--- a/webots_ros2_universal_robot/resource/ros2_control_abb_config.yaml
+++ b/webots_ros2_universal_robot/resource/ros2_control_abb_config.yaml
@@ -1,7 +1,7 @@
 /**:
   ros__parameters:
     # controller_manager
-    update_rate: 20.0
+    update_rate: 20
 
     abb_joint_trajectory_controller:
       type: joint_trajectory_controller/JointTrajectoryController

--- a/webots_ros2_universal_robot/resource/ros2_control_config.yaml
+++ b/webots_ros2_universal_robot/resource/ros2_control_config.yaml
@@ -2,7 +2,7 @@
 /**:
   ros__parameters:
     # controller_manager
-    update_rate: 20.0
+    update_rate: 20
     ur_joint_trajectory_controller:
       type: joint_trajectory_controller/JointTrajectoryController
     ur_joint_state_broadcaster:


### PR DESCRIPTION
This PR is to solve the romve of `base_interface` from `hardware_interface` from `ros2control` as it makes the rolling testing test fail on CI.

Also it impacts `ROS Galactic`.

This take work from @Timple from this PR #313 and insure compatibility with `foxy`.