### PR TITLE
Fix buildfarm withour ROS_DISTRO defined

### DIFF
--- a/webots_ros2_control/package.xml
+++ b/webots_ros2_control/package.xml
@@ -16,6 +16,8 @@
   <depend>rclcpp</depend>
   <depend>webots_ros2_driver</depend>
 
+  <build_depend>ros_environment</build_depend>
+
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
**Description**
This should solved the issue on the buildfarm as `ROS_DISTRO` is not defined.
Including the `ros_environnement` package should solve this according to this [PR](https://github.com/ros/rosdistro/issues/29465).
