### PR TITLE
fix: 🐛 link error when build libwebots_ros2_control on macOS

### DIFF
--- a/webots_ros2_control/CMakeLists.txt
+++ b/webots_ros2_control/CMakeLists.txt
@@ -56,6 +56,7 @@ ament_target_dependencies(
   rclcpp
   webots_ros2_driver
 )
+
 # Prevent pluginlib from using boost
 target_compile_definitions(${PROJECT_NAME} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 pluginlib_export_plugin_description_file(webots_ros2_driver webots_ros2_control.xml)
@@ -71,7 +72,6 @@ target_include_directories(
   PRIVATE
   include
 )
-
 ament_target_dependencies(
   ${PROJECT_NAME}_system
   hardware_interface

--- a/webots_ros2_control/CMakeLists.txt
+++ b/webots_ros2_control/CMakeLists.txt
@@ -72,6 +72,22 @@ target_include_directories(
   PRIVATE
   include
 )
+
+if (APPLE)
+  set(WEBOTS_LIB_BASE webots/lib/darwin19)
+  set(WEBOTS_DRIVER_DARWIN ${CMAKE_SOURCE_DIR}/../webots_ros2_driver/${WEBOTS_LIB_BASE})
+  target_link_libraries(
+    ${PROJECT_NAME}_system
+    ${WEBOTS_DRIVER_DARWIN}/libController.dylib
+    ${WEBOTS_DRIVER_DARWIN}/libCppCar.dylib
+    ${WEBOTS_DRIVER_DARWIN}/libCppController.dylib
+    ${WEBOTS_DRIVER_DARWIN}/libCppDriver.dylib
+    ${WEBOTS_DRIVER_DARWIN}/libcar.dylib
+    ${WEBOTS_DRIVER_DARWIN}/libdriver.dylib
+)
+endif ()
+
+
 ament_target_dependencies(
   ${PROJECT_NAME}_system
   hardware_interface

--- a/webots_ros2_control/CMakeLists.txt
+++ b/webots_ros2_control/CMakeLists.txt
@@ -56,7 +56,6 @@ ament_target_dependencies(
   rclcpp
   webots_ros2_driver
 )
-
 # Prevent pluginlib from using boost
 target_compile_definitions(${PROJECT_NAME} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 pluginlib_export_plugin_description_file(webots_ros2_driver webots_ros2_control.xml)

--- a/webots_ros2_control/CMakeLists.txt
+++ b/webots_ros2_control/CMakeLists.txt
@@ -73,21 +73,6 @@ target_include_directories(
   include
 )
 
-if (APPLE)
-  set(WEBOTS_LIB_BASE webots/lib/darwin19)
-  set(WEBOTS_DRIVER_DARWIN ${CMAKE_SOURCE_DIR}/../webots_ros2_driver/${WEBOTS_LIB_BASE})
-  target_link_libraries(
-    ${PROJECT_NAME}_system
-    ${WEBOTS_DRIVER_DARWIN}/libController.dylib
-    ${WEBOTS_DRIVER_DARWIN}/libCppCar.dylib
-    ${WEBOTS_DRIVER_DARWIN}/libCppController.dylib
-    ${WEBOTS_DRIVER_DARWIN}/libCppDriver.dylib
-    ${WEBOTS_DRIVER_DARWIN}/libcar.dylib
-    ${WEBOTS_DRIVER_DARWIN}/libdriver.dylib
-)
-endif ()
-
-
 ament_target_dependencies(
   ${PROJECT_NAME}_system
   hardware_interface

--- a/webots_ros2_driver/CMakeLists.txt
+++ b/webots_ros2_driver/CMakeLists.txt
@@ -221,5 +221,6 @@ ament_export_dependencies(
 )
 ament_export_libraries(
   ${PROJECT_NAME}_imu
+  ${WEBOTS_LIB}
 )
 ament_package()


### PR DESCRIPTION
fix link error when build libwebots_ros2_control_system.dylib on macOS
ros2 version : foxy
operating system : macOS catalina

✅ Closes: #344

**Description**
fix Link error when build libwebots_ros2_control_system.dylib on macOS

**Related Issues**
This pull-request fixes issue #344 

**Affected Packages**
List of affected packages:
  - webots_ros2_controller

**Additional context**
Maybe there have some issues to build webs_ros2 package on macOS Catalina if you install ros2 from binary package,
here is solutions:
```
rosinstall_generator ros2_control control_msgs ros2_controllers controller_interface controller_manager controller_manager_msgs hardware_interface joint_limits_interface ros2_control_test_assets ros2controlcli transmission_interface --rosdistro foxy > deps.repos
mkdir src
vcs import src < deps.repos
colcon build --merge-install
rosinstall_generator vision_msgs ackermann_msgs angles realtime_tools --rosdistro foxy > deps.repos
vcs import src < deps.repos
colcon build --merge-install
git clone --recurse-submodules -b foxy https://github.com/cyberbotics/webots_ros2.git src/webots_ros2
colcon build --merge-install
```
 