### PR TITLE
Move `rclcpp_lifecycle` dependency to `webots_ros2_control`

### DIFF
--- a/webots_ros2_control/CMakeLists.txt
+++ b/webots_ros2_control/CMakeLists.txt
@@ -26,6 +26,7 @@ find_package(hardware_interface REQUIRED)
 find_package(controller_manager REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
 find_package(webots_ros2_driver REQUIRED)
 
 list(GET webots_ros2_driver_INCLUDE_DIRS 0 webots_ros2_driver_INCLUDE)
@@ -77,6 +78,7 @@ ament_target_dependencies(
   hardware_interface
   pluginlib
   rclcpp
+  rclcpp_lifecycle
   webots_ros2_driver
 )
 
@@ -100,6 +102,7 @@ ament_export_dependencies(
   hardware_interface
   pluginlib
   rclcpp
+  rclcpp_lifecycle
 )
 ament_export_libraries(
   ${PROJECT_NAME}

--- a/webots_ros2_control/package.xml
+++ b/webots_ros2_control/package.xml
@@ -14,6 +14,8 @@
   <depend>controller_manager</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>
+  <depend>rclcpp_lifecycle</depend>
+
   <depend>webots_ros2_driver</depend>
 
   <build_depend>ros_environment</build_depend>

--- a/webots_ros2_driver/CMakeLists.txt
+++ b/webots_ros2_driver/CMakeLists.txt
@@ -10,7 +10,6 @@ find_package(ament_cmake_python REQUIRED)
 find_package(rosgraph_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(pluginlib REQUIRED)
-find_package(rclcpp_lifecycle REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
@@ -105,7 +104,6 @@ ament_target_dependencies(driver
   rosgraph_msgs
   rclcpp
   pluginlib
-  rclcpp_lifecycle
   sensor_msgs
   std_msgs
   tf2_ros
@@ -209,7 +207,6 @@ pluginlib_export_plugin_description_file(${PROJECT_NAME} webots_ros2_imu.xml)
 ament_export_include_directories(include)
 ament_export_dependencies(
   rclcpp
-  rclcpp_lifecycle
   rclpy
   sensor_msgs
   std_msgs

--- a/webots_ros2_driver/package.xml
+++ b/webots_ros2_driver/package.xml
@@ -16,7 +16,6 @@
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>
   <depend>rclpy</depend>
-  <depend>rclcpp_lifecycle</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
   <depend>tf2_ros</depend>


### PR DESCRIPTION
`webots_ros2_driver` doesn't depend on `rclcpp_lifecycle`, but `webots_ros2_control` only