### PR TITLE
Simplify C++ plugins

### DIFF
--- a/webots_ros2_control/CMakeLists.txt
+++ b/webots_ros2_control/CMakeLists.txt
@@ -29,11 +29,6 @@ find_package(rclcpp REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
 find_package(webots_ros2_driver REQUIRED)
 
-list(GET webots_ros2_driver_INCLUDE_DIRS 0 webots_ros2_driver_INCLUDE)
-include_directories(
-  ${webots_ros2_driver_INCLUDE}/webots/cpp
-)
-
 if (MSVC OR MSYS OR MINGW OR WIN32)
   set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 endif()

--- a/webots_ros2_driver/CMakeLists.txt
+++ b/webots_ros2_driver/CMakeLists.txt
@@ -204,7 +204,11 @@ target_compile_definitions(${PROJECT_NAME}_imu PUBLIC "PLUGINLIB__DISABLE_BOOST_
 pluginlib_export_plugin_description_file(${PROJECT_NAME} webots_ros2_imu.xml)
 
 # Ament export
-ament_export_include_directories(include)
+ament_export_include_directories(
+  include
+  include/webots/c
+  include/webots/cpp
+)
 ament_export_dependencies(
   rclcpp
   rclpy


### PR DESCRIPTION
Export libController include files, so plugin developers don't have to include them explicitly