### PR TITLE
Fix LiDAR transform

### DIFF
--- a/webots_ros2_core/webots_ros2_core/utils.py
+++ b/webots_ros2_core/webots_ros2_core/utils.py
@@ -33,8 +33,8 @@ from launch.action import Action
 from launch.launch_context import LaunchContext
 
 
-MINIMUM_VERSION_STR = 'R2021c'
-TARGET_VERSION_STR = 'R2021c'
+MINIMUM_VERSION_STR = 'R2022a'
+TARGET_VERSION_STR = 'R2022a'
 
 
 @functools.total_ordering

--- a/webots_ros2_driver/src/plugins/static/Ros2Lidar.cpp
+++ b/webots_ros2_driver/src/plugins/static/Ros2Lidar.cpp
@@ -33,7 +33,7 @@ namespace webots_ros2_driver
     {
       mLaserPublisher = mNode->create_publisher<sensor_msgs::msg::LaserScan>(mTopicName, rclcpp::SensorDataQoS().reliable());
       const int resolution = mLidar->getHorizontalResolution();
-      mLaserMessage.header.frame_id = mFrameName + "_rotated";
+      mLaserMessage.header.frame_id = mFrameName;
       mLaserMessage.angle_increment = mLidar->getFov() / resolution;
       mLaserMessage.angle_min = -mLidar->getFov() / 2.0;
       mLaserMessage.angle_max = mLidar->getFov() / 2.0 - mLaserMessage.angle_increment;
@@ -42,16 +42,6 @@ namespace webots_ros2_driver
       mLaserMessage.range_min = mLidar->getMinRange();
       mLaserMessage.range_max = mLidar->getMaxRange();
       mLaserMessage.ranges.resize(resolution);
-
-      mTfBroadcaster = std::make_unique<tf2_ros::StaticTransformBroadcaster>(mNode);
-      auto transformStamped = geometry_msgs::msg::TransformStamped();
-      transformStamped.header.frame_id = mFrameName;
-      transformStamped.child_frame_id = mFrameName + "_rotated";
-      transformStamped.transform.rotation.x = 0.5;
-      transformStamped.transform.rotation.y = 0.5;
-      transformStamped.transform.rotation.z = -0.5;
-      transformStamped.transform.rotation.w = 0.5;
-      mTfBroadcaster->sendTransform(transformStamped);
     }
 
     // Point cloud publisher

--- a/webots_ros2_driver/src/plugins/static/Ros2Lidar.cpp
+++ b/webots_ros2_driver/src/plugins/static/Ros2Lidar.cpp
@@ -34,9 +34,9 @@ namespace webots_ros2_driver
       mLaserPublisher = mNode->create_publisher<sensor_msgs::msg::LaserScan>(mTopicName, rclcpp::SensorDataQoS().reliable());
       const int resolution = mLidar->getHorizontalResolution();
       mLaserMessage.header.frame_id = mFrameName;
-      mLaserMessage.angle_increment = mLidar->getFov() / resolution;
-      mLaserMessage.angle_min = -mLidar->getFov() / 2.0;
-      mLaserMessage.angle_max = mLidar->getFov() / 2.0 - mLaserMessage.angle_increment;
+      mLaserMessage.angle_increment = -mLidar->getFov() / resolution;
+      mLaserMessage.angle_min = mLidar->getFov() / 2.0 - mLaserMessage.angle_increment;
+      mLaserMessage.angle_max = -mLidar->getFov() / 2.0;
       mLaserMessage.time_increment = (double)mLidar->getSamplingPeriod() / (1000.0 * resolution);
       mLaserMessage.scan_time = (double)mLidar->getSamplingPeriod() / 1000.0;
       mLaserMessage.range_min = mLidar->getMinRange();

--- a/webots_ros2_driver/webots_ros2_driver/utils.py
+++ b/webots_ros2_driver/webots_ros2_driver/utils.py
@@ -27,8 +27,8 @@ import urllib.request
 from pathlib import Path
 
 
-MINIMUM_VERSION_STR = 'R2021b'
-TARGET_VERSION_STR = 'R2021b'
+MINIMUM_VERSION_STR = 'R2022a'
+TARGET_VERSION_STR = 'R2022a'
 
 
 @functools.total_ordering

--- a/webots_ros2_tests/test/test_system_driver.py
+++ b/webots_ros2_tests/test/test_system_driver.py
@@ -23,6 +23,7 @@ import time
 import pathlib
 import pytest
 import rclpy
+from sensor_msgs.msg import LaserScan
 from std_srvs.srv import Trigger
 from sensor_msgs.msg import Range, Image, Imu, Illuminance
 from std_msgs.msg import Int32, Float32
@@ -81,6 +82,16 @@ class TestDriver(TestWebots):
     def setUp(self):
         self.__node = rclpy.create_node('driver_tester')
         self.wait_for_clock(self.__node, messages_to_receive=20)
+
+    def testLidar(self):
+        def on_message_received(message):
+            # There should be some scans hitting the box
+            for value in message.ranges:
+                if abs(value - 0.6749) < 0.01:
+                    return True
+            return False
+
+        self.wait_for_messages(self.__node, LaserScan, '/scan', condition=on_message_received)
 
     def testRangeFinder(self):
         def on_image_received(message):

--- a/webots_ros2_tests/worlds/driver_test.wbt
+++ b/webots_ros2_tests/worlds/driver_test.wbt
@@ -18,6 +18,9 @@ CardboardBox {
 Pioneer3at {
   controller "<extern>"
   extensionSlot [
+    RobotisLds01 {
+      translation 0.18 0 0.3
+    }
     LightSensor {
       translation 0 0 0.29
     }
@@ -50,10 +53,6 @@ Pioneer3at {
       boundingObject USE ROD_SHAPE
       physics Physics {
       }
-    }
-    VelodyneVLP-16 {
-      translation 0.2 0 0.31
-      rotation 0 0 1 1.5708
     }
   ]
 }

--- a/webots_ros2_turtlebot/resource/ros2control.yml
+++ b/webots_ros2_turtlebot/resource/ros2control.yml
@@ -17,3 +17,9 @@ diffdrive_controller:
     wheel_radius: 0.033
 
     use_stamped_vel: false
+
+joint_state_broadcaster:
+  ros__parameters:
+    extra_joints:
+      - LDS-01_secondary_motor
+      - LDS-01_main_motor

--- a/webots_ros2_universal_robot/package.xml
+++ b/webots_ros2_universal_robot/package.xml
@@ -22,6 +22,7 @@
   <exec_depend>controller_manager</exec_depend>
   <exec_depend>joint_trajectory_controller</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
+  <exec_depend>moveit</exec_depend>
 
   <!-- These test dependencies are optional
   Their purpose is to make sure that the code passes the linters -->

--- a/webots_ros2_universal_robot/package.xml
+++ b/webots_ros2_universal_robot/package.xml
@@ -22,7 +22,6 @@
   <exec_depend>controller_manager</exec_depend>
   <exec_depend>joint_trajectory_controller</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
-  <exec_depend>moveit</exec_depend>
 
   <!-- These test dependencies are optional
   Their purpose is to make sure that the code passes the linters -->


### PR DESCRIPTION
Fixes #366

**Tasks**
- [x] Fix LiDAR transform
- [x] Add more LiDAR tests
- [x] Verify the related tutorials manually
- [x] Verify point cloud messages
- [x] Revert temporary deleted MoveIt dependency
- Not related problems:
  - [x] Fix Webots version
  - [x] Fix the missing transforms

**Note**
- The tests are passing without the MoveIt dependency, so it seems there is a temporary problem on the ROS side.
- It might be possible that we inverted the order of the LiDAR scan in Webots.
- We should do another release with this fix as soon as possible (before ROS syncs).