### PR TITLE
Create an option for "webots_ros2_driver" to publish "robot_description" for "robot_state_publisher" node

### DIFF
--- a/webots_ros2_driver/include/webots_ros2_driver/WebotsNode.hpp
+++ b/webots_ros2_driver/include/webots_ros2_driver/WebotsNode.hpp
@@ -52,6 +52,7 @@ namespace webots_ros2_driver
 
     std::string mRobotName;
     std::string mRobotDescription;
+    bool mSetRobotStatePublisher;
 
     rclcpp::TimerBase::SharedPtr mTimer;
     int mStep;

--- a/webots_ros2_driver/src/WebotsNode.cpp
+++ b/webots_ros2_driver/src/WebotsNode.cpp
@@ -42,6 +42,7 @@ namespace webots_ros2_driver
   WebotsNode::WebotsNode(std::string name, webots::Supervisor *robot) : Node(name), mRobot(robot), mPluginLoader(gPluginInterfaceName, gPluginInterface)
   {
     mRobotDescription = this->declare_parameter<std::string>("robot_description", "");
+    mSetRobotStatePublisher = this->declare_parameter<bool>("set_robot_state_publisher", false);
     if (mRobotDescription != "")
     {
       mRobotDescriptionDocument = std::make_shared<tinyxml2::XMLDocument>();
@@ -112,7 +113,8 @@ namespace webots_ros2_driver
 
   void WebotsNode::init()
   {
-    setAnotherNodeParameter("robot_state_publisher", "robot_description", mRobot->getUrdf());
+    if (mSetRobotStatePublisher)
+      setAnotherNodeParameter("robot_state_publisher", "robot_description", mRobot->getUrdf());
 
     mStep = mRobot->getBasicTimeStep();
     mTimer = this->create_wall_timer(std::chrono::milliseconds(1), std::bind(&WebotsNode::timerCallback, this));

--- a/webots_ros2_epuck/launch/robot_launch.py
+++ b/webots_ros2_epuck/launch/robot_launch.py
@@ -70,7 +70,8 @@ def generate_launch_description():
         output='screen',
         parameters=[
             {'robot_description': robot_description,
-             'use_sim_time': use_sim_time},
+             'use_sim_time': use_sim_time,
+             'set_robot_state_publisher': True},
             ros2_control_params
         ],
         remappings=[

--- a/webots_ros2_tiago/launch/robot_launch.py
+++ b/webots_ros2_tiago/launch/robot_launch.py
@@ -73,7 +73,8 @@ def generate_launch_description():
         output='screen',
         parameters=[
             {'robot_description': robot_description,
-             'use_sim_time': use_sim_time},
+             'use_sim_time': use_sim_time,
+             'set_robot_state_publisher': True},
             ros2_control_params
         ],
         remappings=[

--- a/webots_ros2_turtlebot/launch/robot_launch.py
+++ b/webots_ros2_turtlebot/launch/robot_launch.py
@@ -65,7 +65,8 @@ def generate_launch_description():
         output='screen',
         parameters=[
             {'robot_description': robot_description,
-             'use_sim_time': use_sim_time},
+             'use_sim_time': use_sim_time,
+             'set_robot_state_publisher': True},
             ros2_control_params
         ],
         remappings=[

--- a/webots_ros2_universal_robot/launch/robot_launch.py
+++ b/webots_ros2_universal_robot/launch/robot_launch.py
@@ -68,6 +68,7 @@ def generate_launch_description():
         parameters=[
             {'robot_description': robot_description},
             {'use_sim_time': True},
+            {'set_robot_state_publisher': True},
             ros2_control_params
         ]
     )


### PR DESCRIPTION
**Description**
Currently `webots_ros2_driver` automatically publish a `robot_description` obtained with `mRobot->getUrdf()` (so the URDF obtained is corresponding either to the PROTO used or to the robot node in the world file) for the `robot_state_publisher` node.

The issue is that `webots_ros2_driver` override the parameter `robot_description`, so a user cannot set it himself. It would be preferable to have an option to specify if `webots_ros2_driver` should publish this `robot_description` in case someone is using a PROTO and in the case the user has an URDF file, he can specify `robot_description` for the `robot_state_publisher` node in the launch file.

**Related Issues**
This pull-request fixes issue #375 