### PR TITLE
Change CI tests to use the latest Webots nightly build

### DIFF
--- a/scripts/ci_after_init.bash
+++ b/scripts/ci_after_init.bash
@@ -3,9 +3,19 @@
 ROS_DISTRO=$1
 ROS_REPO=$2
 
+# Take the latest nightly build
+YESTERDAY_WEEK_DAY_NUMBER=`date --date="1 day ago" +"%u"`
+LAST_NIGHTLY_DAY_OLD=1
+# There is no nightly build the weekend
+if [ ${YESTERDAY_WEEK_DAY_NUMBER} -gt 5 ]; then
+    LAST_NIGHTLY_DAY_OLD="$((${YESTERDAY_WEEK_DAY_NUMBER}-4))"
+fi
+NIGHTLY_DATE=`date --date="${LAST_NIGHTLY_DAY_OLD} day ago" +"%d_%m_%Y"`
+WEBOTS_NIGHTLY_VERSION="nightly_${NIGHTLY_DATE}"
+
 apt update
 apt install -y wget dialog apt-utils psmisc
-wget https://github.com/cyberbotics/webots/releases/download/R${WEBOTS_VERSION}/webots_${WEBOTS_VERSION}_amd64.deb -O /tmp/webots.deb
+wget https://github.com/cyberbotics/webots/releases/download/R${WEBOTS_NIGHTLY_VERSION}/webots_${WEBOTS_RELEASE_VERSION}_amd64.deb -O /tmp/webots.deb
 apt install -y /tmp/webots.deb xvfb
 
 # The following packages are only available in the ROS 2 Foxy distribution. Therefore, we cannot include them in the package.xml, but we have to install them manually here.

--- a/scripts/ci_after_init.bash
+++ b/scripts/ci_after_init.bash
@@ -10,12 +10,12 @@ LAST_NIGHTLY_DAY_OLD=1
 if [ ${YESTERDAY_WEEK_DAY_NUMBER} -gt 5 ]; then
     LAST_NIGHTLY_DAY_OLD="$((${YESTERDAY_WEEK_DAY_NUMBER}-4))"
 fi
-NIGHTLY_DATE=`date --date="${LAST_NIGHTLY_DAY_OLD} day ago" +"%d_%m_%Y"`
+NIGHTLY_DATE=`date --date="${LAST_NIGHTLY_DAY_OLD} day ago" +"%-d_%-m_%Y"`
 WEBOTS_NIGHTLY_VERSION="nightly_${NIGHTLY_DATE}"
 
 apt update
 apt install -y wget dialog apt-utils psmisc
-wget https://github.com/cyberbotics/webots/releases/download/R${WEBOTS_NIGHTLY_VERSION}/webots_${WEBOTS_RELEASE_VERSION}_amd64.deb -O /tmp/webots.deb
+wget https://github.com/cyberbotics/webots/releases/download/${WEBOTS_NIGHTLY_VERSION}/webots_${WEBOTS_RELEASE_VERSION}_amd64.deb -O /tmp/webots.deb
 apt install -y /tmp/webots.deb xvfb
 
 # The following packages are only available in the ROS 2 Foxy distribution. Therefore, we cannot include them in the package.xml, but we have to install them manually here.

--- a/scripts/ci_before_init_embed.bash
+++ b/scripts/ci_before_init_embed.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-export WEBOTS_VERSION=2022a
+export WEBOTS_RELEASE_VERSION=2022a
 export WEBOTS_OFFSCREEN=1
 export CI=1
 export DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
**Description**
In order to be up to date with the `master` and `develop` branches from the `webots` repos, it is better to use nightly build of Webots instead of the official releases in order to get the latest features and bug fixes
