### PR TITLE
Fix deprecation warnings webots ros2 core

### DIFF
--- a/webots_ros2_core/CHANGELOG.rst
+++ b/webots_ros2_core/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package webots_ros2_core
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+1.2.3 (2022-02-22)
+------------------
+* This package shows now deprecation warnings and will be removed with the release of Webots `R2023a`.
+* Users of `webots_ros2_core` should migrate to `webots_ros2_driver`.
+
 1.1.2 (2021-11-03)
 ------------------
 * This package is now deprecated.

--- a/webots_ros2_core/README.md
+++ b/webots_ros2_core/README.md
@@ -1,8 +1,12 @@
 # Core
 
+> **Note:** This package has been deprecated and will be removed with the release of Webots `R2023a`.
+>
+>  Users of `webots_ros2_core` should migrate to `webots_ros2_driver`.
+
 This package contains essential building blocks for running Webots simulation, such as Webots launcher, ROS2 wrappers for Webots devices and other relevant utils.
 
 Please use the following links for more details:
 
-* [Tutorial: Write ROS2 Driver](https://github.com/cyberbotics/webots_ros2/wiki/Tutorial-Write-ROS2-Driver)
-* [References](https://github.com/cyberbotics/webots_ros2/wiki/References)
+* [Tutorial: Write ROS2 Driver](https://github.com/cyberbotics/webots_ros2/wiki/Deprecated-Tutorial-Write-ROS2-Driver)
+* [References](https://github.com/cyberbotics/webots_ros2/wiki/Deprecated-References)

--- a/webots_ros2_core/package.xml
+++ b/webots_ros2_core/package.xml
@@ -27,6 +27,6 @@
 
   <export>
     <build_type>ament_python</build_type>
-    <deprecated>This package has been deprecated. Users of webots_ros2_core should migrate to webots_ros2_driver.</deprecated>
+    <deprecated>This package will be removed in Webots R2023a. Users of webots_ros2_core should migrate to webots_ros2_driver.</deprecated>
   </export>
 </package>

--- a/webots_ros2_core/package.xml
+++ b/webots_ros2_core/package.xml
@@ -27,5 +27,6 @@
 
   <export>
     <build_type>ament_python</build_type>
+    <deprecated>This package has been deprecated. Users of webots_ros2_core should migrate to webots_ros2_driver.</deprecated>
   </export>
 </package>

--- a/webots_ros2_core/setup.py
+++ b/webots_ros2_core/setup.py
@@ -1,6 +1,14 @@
 """webots_ros2 package setup file."""
 
 from setuptools import setup
+import logging
+
+logging.basicConfig()
+webots_ros2_core_logger = logging.getLogger('webots_ros2_core')
+webots_ros2_core_logger.warning(
+    ' This package will be removed with the release of Webots R2023a.'
+    ' Use "webots_ros2_driver" instead.'
+    .format_map(locals()))
 
 package_name = 'webots_ros2_core'
 data_files = []

--- a/webots_ros2_core/webots_ros2_core/__init__.py
+++ b/webots_ros2_core/webots_ros2_core/__init__.py
@@ -11,3 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import logging
+logging.basicConfig()
+webots_ros2_core_logger = logging.getLogger('webots_ros2_core')
+webots_ros2_core_logger.warning(
+    ' This package will be removed with the release of Webots R2023a.'
+    ' Use "webots_ros2_driver" instead.'
+    .format_map(locals()))

--- a/webots_ros2_mavic/package.xml
+++ b/webots_ros2_mavic/package.xml
@@ -13,7 +13,7 @@
 
   <exec_depend>rclpy</exec_depend>
   <exec_depend>builtin_interfaces</exec_depend>
-  <depend>webots_ros2_core</depend>
+  <exec_depend>webots_ros2_core</exec_depend>
 
   <!-- These test dependencies are optional
   Their purpose is to make sure that the code passes the linters -->

--- a/webots_ros2_mavic/package.xml
+++ b/webots_ros2_mavic/package.xml
@@ -13,7 +13,7 @@
 
   <exec_depend>rclpy</exec_depend>
   <exec_depend>builtin_interfaces</exec_depend>
-  <exec_depend>webots_ros2_core</exec_depend>
+  <depend>webots_ros2_core</depend>
 
   <!-- These test dependencies are optional
   Their purpose is to make sure that the code passes the linters -->

--- a/webots_ros2_tests/test/test_system_driver.py
+++ b/webots_ros2_tests/test/test_system_driver.py
@@ -87,7 +87,7 @@ class TestDriver(TestWebots):
         def on_message_received(message):
             # There should be some scans hitting the box
             for value in message.ranges:
-                if abs(value - 0.6749) < 0.01:
+                if abs(value - 0.76) < 0.01:
                     return True
             return False
 


### PR DESCRIPTION
**Description**
`webots_ros2_core` has been deprecated in favor of `webots_ros2_driver` for almost 6 months but there was no indication or warning for the user when using the interface.

This PR add a warning during the build from source and when using the package.

**Related Issues**
This pull-request partially fixes issue #359.