### PR TITLE
Fix position + velocity control in ros2_control

### DIFF
--- a/webots_ros2_control/src/Ros2ControlSystem.cpp
+++ b/webots_ros2_control/src/Ros2ControlSystem.cpp
@@ -54,44 +54,43 @@ namespace webots_ros2_control
         if (commandInterface.name == "position")
           joint.controlPosition = true;
         else if (commandInterface.name == "velocity")
-        {
           joint.controlVelocity = true;
-          if (joint.motor)
-          {
-            joint.motor->setPosition(INFINITY);
-            joint.motor->setVelocity(0.0);
-          }
-        }
         else if (commandInterface.name == "effort")
           joint.controlEffort = true;
         else
           throw std::runtime_error("Invalid hardware info name `" + commandInterface.name + "`");
       }
 
+      if (joint.motor && joint.controlVelocity && !joint.controlPosition)
+      {
+        joint.motor->setPosition(INFINITY);
+        joint.motor->setVelocity(0.0);
+      }
+
       mJoints.push_back(joint);
     }
   }
 
-  #if FOXY
-    hardware_interface::return_type Ros2ControlSystem::configure(const hardware_interface::HardwareInfo &info)
+#if FOXY
+  hardware_interface::return_type Ros2ControlSystem::configure(const hardware_interface::HardwareInfo &info)
+  {
+    if (configure_default(info) != hardware_interface::return_type::OK)
     {
-      if (configure_default(info) != hardware_interface::return_type::OK)
-      {
-        return hardware_interface::return_type::ERROR;
-      }
-      status_ = hardware_interface::status::CONFIGURED;
-      return hardware_interface::return_type::OK;
+      return hardware_interface::return_type::ERROR;
     }
-  #else
-    CallbackReturn Ros2ControlSystem::on_init(const hardware_interface::HardwareInfo &info)
+    status_ = hardware_interface::status::CONFIGURED;
+    return hardware_interface::return_type::OK;
+  }
+#else
+  CallbackReturn Ros2ControlSystem::on_init(const hardware_interface::HardwareInfo &info)
+  {
+    if (hardware_interface::SystemInterface::on_init(info) != CallbackReturn::SUCCESS)
     {
-      if (hardware_interface::SystemInterface::on_init(info) != CallbackReturn::SUCCESS)
-      {
-        return CallbackReturn::ERROR;
-      }
-      return CallbackReturn::SUCCESS;
+      return CallbackReturn::ERROR;
     }
-  #endif
+    return CallbackReturn::SUCCESS;
+  }
+#endif
 
   std::vector<hardware_interface::StateInterface> Ros2ControlSystem::export_state_interfaces()
   {
@@ -119,29 +118,29 @@ namespace webots_ros2_control
     return interfaces;
   }
 
-  #if FOXY
-    hardware_interface::return_type Ros2ControlSystem::start()
-    {
-      status_ = hardware_interface::status::STARTED;
-      return hardware_interface::return_type::OK;
-    }
+#if FOXY
+  hardware_interface::return_type Ros2ControlSystem::start()
+  {
+    status_ = hardware_interface::status::STARTED;
+    return hardware_interface::return_type::OK;
+  }
 
-    hardware_interface::return_type Ros2ControlSystem::stop()
-    {
-      status_ = hardware_interface::status::STOPPED;
-      return hardware_interface::return_type::OK;
-    }
-  #else
-    CallbackReturn Ros2ControlSystem::on_activate(const rclcpp_lifecycle::State & /*previous_state*/)
-    {
-      return CallbackReturn::SUCCESS;
-    }
+  hardware_interface::return_type Ros2ControlSystem::stop()
+  {
+    status_ = hardware_interface::status::STOPPED;
+    return hardware_interface::return_type::OK;
+  }
+#else
+  CallbackReturn Ros2ControlSystem::on_activate(const rclcpp_lifecycle::State & /*previous_state*/)
+  {
+    return CallbackReturn::SUCCESS;
+  }
 
-    CallbackReturn Ros2ControlSystem::on_deactivate(const rclcpp_lifecycle::State & /*previous_state*/)
-    {
-      return CallbackReturn::SUCCESS;
-    }
-  #endif
+  CallbackReturn Ros2ControlSystem::on_deactivate(const rclcpp_lifecycle::State & /*previous_state*/)
+  {
+    return CallbackReturn::SUCCESS;
+  }
+#endif
 
   hardware_interface::return_type Ros2ControlSystem::read()
   {
@@ -163,7 +162,11 @@ namespace webots_ros2_control
         if (joint.controlPosition && !std::isnan(joint.positionCommand))
           joint.motor->setPosition(joint.positionCommand);
         if (joint.controlVelocity && !std::isnan(joint.velocityCommand))
-          joint.motor->setVelocity(joint.velocityCommand);
+        {
+          // In the position control mode the velocity cannot be negative.
+          const double velocityCommand = joint.controlPosition ? abs(joint.velocityCommand) : joint.velocityCommand;
+          joint.motor->setVelocity(velocityCommand);
+        }
         if (joint.controlEffort && !std::isnan(joint.effortCommand))
           joint.motor->setTorque(joint.effortCommand);
       }

--- a/webots_ros2_driver/src/plugins/static/Ros2Camera.cpp
+++ b/webots_ros2_driver/src/plugins/static/Ros2Camera.cpp
@@ -46,16 +46,17 @@ namespace webots_ros2_driver
     mCameraInfoMessage.height = mCamera->getHeight();
     mCameraInfoMessage.width = mCamera->getWidth();
     mCameraInfoMessage.distortion_model = "plumb_bob";
-    const double focalLength = (mCamera->getFocalLength() == 0) ? 570.34 : mCamera->getFocalLength();
+    const double focalLengthX = 0.5 * mCamera->getWidth() * (1 / tan(0.5 * mCamera->getFov()));
+    const double focalLengthY = 0.5 * mCamera->getHeight() * (1 / tan(0.5 * mCamera->getFov()));
     mCameraInfoMessage.d = {0.0, 0.0, 0.0, 0.0, 0.0};
     mCameraInfoMessage.r = {1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0};
     mCameraInfoMessage.k = {
-        focalLength, 0.0, (double)mCamera->getWidth() / 2,
-        0.0, focalLength, (double)mCamera->getHeight() / 2,
+        focalLengthX, 0.0, (double)mCamera->getWidth() / 2,
+        0.0, focalLengthY, (double)mCamera->getHeight() / 2,
         0.0, 0.0, 1.0};
     mCameraInfoMessage.p = {
-        focalLength, 0.0, (double)mCamera->getWidth() / 2, 0.0,
-        0.0, focalLength, (double)mCamera->getHeight() / 2, 0.0,
+        focalLengthX, 0.0, (double)mCamera->getWidth() / 2, 0.0,
+        0.0, focalLengthY, (double)mCamera->getHeight() / 2, 0.0,
         0.0, 0.0, 1.0, 0.0};
     mCameraInfoPublisher->publish(mCameraInfoMessage);
 


### PR DESCRIPTION
**Description**
This PR solves two bugs (sorry for putting everything in a single PR):
- Allows combining position and velocity control in the ros2_control interface. This is often used with robotic arms, e.g. without it moveit_servo prints singularity warnings all over the place.
- Corrects the focal length in the camera_info topic. The focal length is now calculated in the same way as in the range finder plugin.

**Affected Packages**
  - webots_ros2_driver
