### PR TITLE
Fix laser publisher

### DIFF
--- a/webots_ros2_driver/src/plugins/static/Ros2Lidar.cpp
+++ b/webots_ros2_driver/src/plugins/static/Ros2Lidar.cpp
@@ -34,8 +34,8 @@ namespace webots_ros2_driver
       mLaserPublisher = mNode->create_publisher<sensor_msgs::msg::LaserScan>(mTopicName, rclcpp::SensorDataQoS().reliable());
       const int resolution = mLidar->getHorizontalResolution();
       mLaserMessage.header.frame_id = mFrameName;
-      mLaserMessage.angle_increment = -mLidar->getFov() / resolution;
-      mLaserMessage.angle_min = mLidar->getFov() / 2.0 - mLaserMessage.angle_increment;
+      mLaserMessage.angle_increment = -mLidar->getFov() / (resolution - 1);
+      mLaserMessage.angle_min = mLidar->getFov() / 2.0;
       mLaserMessage.angle_max = -mLidar->getFov() / 2.0;
       mLaserMessage.time_increment = (double)mLidar->getSamplingPeriod() / (1000.0 * resolution);
       mLaserMessage.scan_time = (double)mLidar->getSamplingPeriod() / 1000.0;
@@ -86,7 +86,7 @@ namespace webots_ros2_driver
 
     if (mAlwaysOn)
       return;
-    
+
     const bool shouldPointCloudBeEnabled = mPointCloudPublisher->get_subscription_count() > 0;
     const bool shouldSensorBeEnabled = shouldPointCloudBeEnabled ||
                                  (mLaserPublisher != nullptr && mLaserPublisher->get_subscription_count() > 0);


### PR DESCRIPTION
**Description**
Addresses: https://github.com/cyberbotics/webots_ros2/issues/424

Currently on the tiago example, slam_toolbox complains about the number of range readings not matching.
The change was introduced here https://github.com/cyberbotics/webots_ros2/pull/367, however I'm not certain why. As far as I can tell, for slam_toolbox the range should be inclusive, so `[-0.5*FOV, 0.5*FOV]`, which is also how it was implemented in [webots_ros2_core ](https://github.com/cyberbotics/webots_ros2/blob/2ad205c9118c91ca442ac052073bb81333561c8a/webots_ros2_core/webots_ros2_core/devices/lidar_device.py#L131-L133). @lukicdarkoo do you recall perhaps why the change was done?