### PR TITLE
Allow custom ros2_control hardware_interface

### DIFF
--- a/webots_ros2_control/CMakeLists.txt
+++ b/webots_ros2_control/CMakeLists.txt
@@ -89,15 +89,19 @@ install(TARGETS
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
 )
+install(
+  DIRECTORY include/
+  DESTINATION include
+)
 ament_export_include_directories(
   include
 )
-
 ament_export_dependencies(
   hardware_interface
   pluginlib
   rclcpp
   rclcpp_lifecycle
+  webots_ros2_driver
 )
 ament_export_libraries(
   ${PROJECT_NAME}


### PR DESCRIPTION
The `webots_ros2_control::Ros2ControlSystem` hardware_interface is generic and it should work for most users. However, sometimes users need to implement a custom `hardware_interface` (e.g. to achieve a certain control behavior). This PR exports the necessary headers for custom interfaces (if I get time I may write a tutorial about it).

**Affected Packages**
  - webots_ros2_control
