### PR TITLE
use new bbox msg signature

### DIFF
--- a/webots_ros2_core/webots_ros2_core/devices/camera_device.py
+++ b/webots_ros2_core/webots_ros2_core/devices/camera_device.py
@@ -188,8 +188,8 @@ class CameraDevice(SensorDevice):
                         hyp.pose.pose.position = position
                         hyp.pose.pose.orientation = orientation
                         reco_obj.results.append(hyp)
-                        reco_obj.bbox.center.x = obj_center[0]
-                        reco_obj.bbox.center.y = obj_center[1]
+                        reco_obj.bbox.center.position.x = obj_center[0]
+                        reco_obj.bbox.center.position.y = obj_center[1]
                         reco_obj.bbox.size_x = obj_size[0]
                         reco_obj.bbox.size_y = obj_size[1]
                         reco_msg.detections.append(reco_obj)
@@ -200,8 +200,8 @@ class CameraDevice(SensorDevice):
                         reco_webots_obj.model = obj_model
                         reco_webots_obj.pose.pose.position = position
                         reco_webots_obj.pose.pose.orientation = orientation
-                        reco_webots_obj.bbox.center.x = obj_center[0]
-                        reco_webots_obj.bbox.center.y = obj_center[1]
+                        reco_webots_obj.bbox.center.position.x = obj_center[0]
+                        reco_webots_obj.bbox.center.position.y = obj_center[1]
                         reco_webots_obj.bbox.size_x = obj_size[0]
                         reco_webots_obj.bbox.size_y = obj_size[1]
                         for i in range(0, obj.get_number_of_colors()):

--- a/webots_ros2_core/webots_ros2_core/devices/camera_device.py
+++ b/webots_ros2_core/webots_ros2_core/devices/camera_device.py
@@ -14,6 +14,7 @@
 
 """Camera device."""
 
+import os
 from sensor_msgs.msg import Image, CameraInfo
 from vision_msgs.msg import Detection2D, Detection2DArray, ObjectHypothesisWithPose
 from geometry_msgs.msg import Point, Quaternion
@@ -188,8 +189,12 @@ class CameraDevice(SensorDevice):
                         hyp.pose.pose.position = position
                         hyp.pose.pose.orientation = orientation
                         reco_obj.results.append(hyp)
-                        reco_obj.bbox.center.position.x = obj_center[0]
-                        reco_obj.bbox.center.position.y = obj_center[1]
+                        if 'ROS_DISTRO' in os.environ and os.environ['ROS_DISTRO'] in ('foxy', 'galactic'):
+                            reco_obj.bbox.center.x = obj_center[0]
+                            reco_obj.bbox.center.y = obj_center[1]
+                        else:
+                            reco_obj.bbox.center.position.x = obj_center[0]
+                            reco_obj.bbox.center.position.y = obj_center[1]
                         reco_obj.bbox.size_x = obj_size[0]
                         reco_obj.bbox.size_y = obj_size[1]
                         reco_msg.detections.append(reco_obj)
@@ -200,8 +205,12 @@ class CameraDevice(SensorDevice):
                         reco_webots_obj.model = obj_model
                         reco_webots_obj.pose.pose.position = position
                         reco_webots_obj.pose.pose.orientation = orientation
-                        reco_webots_obj.bbox.center.position.x = obj_center[0]
-                        reco_webots_obj.bbox.center.position.y = obj_center[1]
+                        if 'ROS_DISTRO' in os.environ and os.environ['ROS_DISTRO'] in ('foxy', 'galactic'):
+                            reco_webots_obj.bbox.center.x = obj_center[0]
+                            reco_webots_obj.bbox.center.y = obj_center[1]
+                        else:
+                            reco_webots_obj.bbox.center.position.x = obj_center[0]
+                            reco_webots_obj.bbox.center.position.y = obj_center[1]
                         reco_webots_obj.bbox.size_x = obj_size[0]
                         reco_webots_obj.bbox.size_y = obj_size[1]
                         for i in range(0, obj.get_number_of_colors()):

--- a/webots_ros2_driver/CMakeLists.txt
+++ b/webots_ros2_driver/CMakeLists.txt
@@ -4,6 +4,13 @@ project(webots_ros2_driver)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Check which ROS distribution is used, vision_msgs depends of that
+if($ENV{ROS_DISTRO} MATCHES "foxy")
+  add_compile_definitions(FOXY)
+elseif($ENV{ROS_DISTRO} MATCHES "galactic")
+  add_compile_definitions(GALACTIC)
+endif()
+
 # ROS2 Packages
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_python REQUIRED)

--- a/webots_ros2_driver/package.xml
+++ b/webots_ros2_driver/package.xml
@@ -9,6 +9,8 @@
   <url type="bugtracker">https://github.com/cyberbotics/webots_ros2/issues</url>
   <url type="repository">https://github.com/cyberbotics/webots_ros2</url>
 
+  <build_depend>ros_environment</build_depend>
+
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>python_cmake_module</buildtool_depend>
   <buildtool_depend>ament_cmake_python</buildtool_depend>

--- a/webots_ros2_driver/src/plugins/static/Ros2Camera.cpp
+++ b/webots_ros2_driver/src/plugins/static/Ros2Camera.cpp
@@ -151,8 +151,13 @@ namespace webots_ros2_driver
       hypothesis.pose.pose.position = position;
       hypothesis.pose.pose.orientation = orientation;
       detection.results.push_back(hypothesis);
+      #if FOXY || GALACTIC
+      detection.bbox.center.x = objects[i].position_on_image[0];
+      detection.bbox.center.y = objects[i].position_on_image[1];
+      #else
       detection.bbox.center.position.x = objects[i].position_on_image[0];
       detection.bbox.center.position.y = objects[i].position_on_image[1];
+      #endif
       detection.bbox.size_x = objects[i].size_on_image[0];
       detection.bbox.size_y = objects[i].size_on_image[1];
       mRecognitionMessage.detections.push_back(detection);
@@ -163,8 +168,13 @@ namespace webots_ros2_driver
       recognitionWebotsObject.model = std::string(objects[i].model);
       recognitionWebotsObject.pose.pose.position = position;
       recognitionWebotsObject.pose.pose.orientation = orientation;
+      #if FOXY || GALACTIC
+      recognitionWebotsObject.bbox.center.x = objects[i].position_on_image[0];
+      recognitionWebotsObject.bbox.center.y = objects[i].position_on_image[1];
+      #else
       recognitionWebotsObject.bbox.center.position.x = objects[i].position_on_image[0];
       recognitionWebotsObject.bbox.center.position.y = objects[i].position_on_image[1];
+      #endif
       recognitionWebotsObject.bbox.size_x = objects[i].size_on_image[0];
       recognitionWebotsObject.bbox.size_y = objects[i].size_on_image[1];
       for (size_t j = 0; j < objects[i].number_of_colors; j++)

--- a/webots_ros2_driver/src/plugins/static/Ros2Camera.cpp
+++ b/webots_ros2_driver/src/plugins/static/Ros2Camera.cpp
@@ -151,8 +151,8 @@ namespace webots_ros2_driver
       hypothesis.pose.pose.position = position;
       hypothesis.pose.pose.orientation = orientation;
       detection.results.push_back(hypothesis);
-      detection.bbox.center.x = objects[i].position_on_image[0];
-      detection.bbox.center.y = objects[i].position_on_image[1];
+      detection.bbox.center.position.x = objects[i].position_on_image[0];
+      detection.bbox.center.position.y = objects[i].position_on_image[1];
       detection.bbox.size_x = objects[i].size_on_image[0];
       detection.bbox.size_y = objects[i].size_on_image[1];
       mRecognitionMessage.detections.push_back(detection);
@@ -163,8 +163,8 @@ namespace webots_ros2_driver
       recognitionWebotsObject.model = std::string(objects[i].model);
       recognitionWebotsObject.pose.pose.position = position;
       recognitionWebotsObject.pose.pose.orientation = orientation;
-      recognitionWebotsObject.bbox.center.x = objects[i].position_on_image[0];
-      recognitionWebotsObject.bbox.center.y = objects[i].position_on_image[1];
+      recognitionWebotsObject.bbox.center.position.x = objects[i].position_on_image[0];
+      recognitionWebotsObject.bbox.center.position.y = objects[i].position_on_image[1];
       recognitionWebotsObject.bbox.size_x = objects[i].size_on_image[0];
       recognitionWebotsObject.bbox.size_y = objects[i].size_on_image[1];
       for (size_t j = 0; j < objects[i].number_of_colors; j++)


### PR DESCRIPTION
**Description**
Match vision_msgs bbox msg to new signature, released in [4.0.0 on **Rolling only**](https://github.com/ros/rosdistro/pull/32485). 

**Error**

Error log when compiling:
```
error: ‘using _center_type = struct vision_msgs::msg::Pose2D_<std::allocator<void> >’ {aka ‘struct vision_msgs::msg::Pose2D_<std::allocator<void> >’} has no member named ‘x’
```

**Related Issues**
No Related Issues

**Affected Packages**
List of affected packages:
  - webots_ros2_core
  - webots_ros2_driver

**Additional context**
Do not back port this to galactic or foxy