### PR TITLE
include string

### DIFF
--- a/webots_ros2_driver/include/webots_ros2_driver/PluginInterface.hpp
+++ b/webots_ros2_driver/include/webots_ros2_driver/PluginInterface.hpp
@@ -16,6 +16,7 @@
 #define PLUGIN_INTERFACE
 
 #include <unordered_map>
+#include <string>
 
 namespace webots_ros2_driver
 {


### PR DESCRIPTION
**Description**

Compiling on ROS2 Rolling, the following error occurs. Simply adding ``#include <string>`` fixes the issue.

```
In file included from /home/ijnek/workspaces_ros2/webots_ros2_ws/src/webots_ros2/webots_ros2_driver/include/webots_ros2_driver/PythonPlugin.hpp:21,
                 from /home/ijnek/workspaces_ros2/webots_ros2_ws/src/webots_ros2/webots_ros2_driver/src/PythonPlugin.cpp:1:
/home/ijnek/workspaces_ros2/webots_ros2_ws/src/webots_ros2/webots_ros2_driver/include/webots_ros2_driver/PluginInterface.hpp:35:69: error: ‘string’ is not a member of ‘std’
   35 |         virtual void init(WebotsNode *node, std::unordered_map<std::string, std::string> &parameters) = 0;
```

**Related Issues**
This pull-request fixes issue #

**Affected Packages**
List of affected packages:
  - webots_ros2_driver
