### PR TITLE
CallbackReturn should include namespace in its signature

### DIFF
--- a/webots_ros2_control/include/webots_ros2_control/Ros2ControlSystem.hpp
+++ b/webots_ros2_control/include/webots_ros2_control/Ros2ControlSystem.hpp
@@ -63,9 +63,9 @@ namespace webots_ros2_control
       hardware_interface::return_type start() override;
       hardware_interface::return_type stop() override;
     #else
-      CallbackReturn on_init(const hardware_interface::HardwareInfo &info) override;
-      CallbackReturn on_activate(const rclcpp_lifecycle::State & /*previous_state*/) override;
-      CallbackReturn on_deactivate(const rclcpp_lifecycle::State & /*previous_state*/) override;
+      rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_init(const hardware_interface::HardwareInfo &info) override;
+      rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_activate(const rclcpp_lifecycle::State & /*previous_state*/) override;
+      rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_deactivate(const rclcpp_lifecycle::State & /*previous_state*/) override;
     #endif
 
     std::vector<hardware_interface::StateInterface> export_state_interfaces() override;

--- a/webots_ros2_control/src/Ros2ControlSystem.cpp
+++ b/webots_ros2_control/src/Ros2ControlSystem.cpp
@@ -87,13 +87,13 @@ namespace webots_ros2_control
     return hardware_interface::return_type::OK;
   }
 #else
-  CallbackReturn Ros2ControlSystem::on_init(const hardware_interface::HardwareInfo &info)
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn Ros2ControlSystem::on_init(const hardware_interface::HardwareInfo &info)
   {
-    if (hardware_interface::SystemInterface::on_init(info) != CallbackReturn::SUCCESS)
+    if (hardware_interface::SystemInterface::on_init(info) != rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS)
     {
-      return CallbackReturn::ERROR;
+      return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR;
     }
-    return CallbackReturn::SUCCESS;
+    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
   }
 #endif
 
@@ -139,14 +139,14 @@ namespace webots_ros2_control
     return hardware_interface::return_type::OK;
   }
 #else
-  CallbackReturn Ros2ControlSystem::on_activate(const rclcpp_lifecycle::State & /*previous_state*/)
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn Ros2ControlSystem::on_activate(const rclcpp_lifecycle::State & /*previous_state*/)
   {
-    return CallbackReturn::SUCCESS;
+    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
   }
 
-  CallbackReturn Ros2ControlSystem::on_deactivate(const rclcpp_lifecycle::State & /*previous_state*/)
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn Ros2ControlSystem::on_deactivate(const rclcpp_lifecycle::State & /*previous_state*/)
   {
-    return CallbackReturn::SUCCESS;
+    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
   }
 #endif
 


### PR DESCRIPTION
**Description**
``CallbackReturn`` should use its full name when compiling on ROS2 Rolling (Ubuntu Jammy).

Error during compilation:

```
/home/ijnek/workspaces_ros2/webots_ros2_ws/src/webots_ros2/webots_ros2_control/src/Ros2ControlSystem.cpp:90:3: error: ‘CallbackReturn’ does not name a type
   90 |   CallbackReturn Ros2ControlSystem::on_init(const hardware_interface::HardwareInfo &info)
```

**Related Issues**
No related issue

**Affected Packages**
List of affected packages:
  - webots_ros2_control
