### PR TITLE
bump python version to 3.10 for rolling

### DIFF
--- a/webots_ros2_driver/CMakeLists.txt
+++ b/webots_ros2_driver/CMakeLists.txt
@@ -24,7 +24,11 @@ find_package(vision_msgs REQUIRED)
 find_package(webots_ros2_msgs REQUIRED)
 find_package(tinyxml2_vendor REQUIRED)
 find_package(TinyXML2 REQUIRED)
-find_package(PythonLibs 3.10 EXACT REQUIRED)
+if($ENV{ROS_DISTRO} MATCHES "foxy" OR $ENV{ROS_DISTRO} MATCHES "galactic")
+  find_package(PythonLibs 3.8 EXACT REQUIRED)
+else()
+  find_package(PythonLibs 3.10 EXACT REQUIRED)
+endif()
 
 if (UNIX AND NOT APPLE)
   set(WEBOTS_LIB_BASE webots/lib/linux-gnu)
@@ -84,8 +88,13 @@ else()
   )
 endif()
 
-ament_python_install_package(${PROJECT_NAME}_webots
-  PACKAGE_DIR ${WEBOTS_LIB_BASE}/python310)
+if($ENV{ROS_DISTRO} MATCHES "foxy" OR $ENV{ROS_DISTRO} MATCHES "galactic")
+  ament_python_install_package(${PROJECT_NAME}_webots
+    PACKAGE_DIR ${WEBOTS_LIB_BASE}/python38)
+else()
+  ament_python_install_package(${PROJECT_NAME}_webots
+    PACKAGE_DIR ${WEBOTS_LIB_BASE}/python310)
+endif()
 
 ament_python_install_package(${PROJECT_NAME}
   PACKAGE_DIR ${PROJECT_NAME})

--- a/webots_ros2_driver/CMakeLists.txt
+++ b/webots_ros2_driver/CMakeLists.txt
@@ -24,7 +24,7 @@ find_package(vision_msgs REQUIRED)
 find_package(webots_ros2_msgs REQUIRED)
 find_package(tinyxml2_vendor REQUIRED)
 find_package(TinyXML2 REQUIRED)
-find_package(PythonLibs 3.8 EXACT REQUIRED)
+find_package(PythonLibs 3.10 EXACT REQUIRED)
 
 if (UNIX AND NOT APPLE)
   set(WEBOTS_LIB_BASE webots/lib/linux-gnu)
@@ -85,7 +85,7 @@ else()
 endif()
 
 ament_python_install_package(${PROJECT_NAME}_webots
-  PACKAGE_DIR ${WEBOTS_LIB_BASE}/python38)
+  PACKAGE_DIR ${WEBOTS_LIB_BASE}/python310)
 
 ament_python_install_package(${PROJECT_NAME}
   PACKAGE_DIR ${PROJECT_NAME})


### PR DESCRIPTION
**Description**
Use Python 3.10 for Rolling on Ubuntu Jammy to fix current CI failure.
**This requires the auto-generated python310 directory in https://github.com/cyberbotics/webots-libcontroller/tree/R2022b/lib/linux-gnu before being merged**, (related to https://github.com/cyberbotics/webots/pull/4474)

Current error log when compiling on Ubuntu Jammy:
```
--- stderr: webots_ros2_driver
  CMake Error at /usr/share/cmake-3.22/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
    Could NOT find PythonLibs (missing: PYTHON_LIBRARIES PYTHON_INCLUDE_DIRS)
    (Required is exact version "3.8")
  Call Stack (most recent call first):
    /usr/share/cmake-3.22/Modules/FindPackageHandleStandardArgs.cmake:594 (_FPHSA_FAILURE_MESSAGE)
    /usr/share/cmake-3.22/Modules/FindPythonLibs.cmake:310 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
    CMakeLists.txt:20 (find_package)
  
  
  ---
```


**Related Issues**
No related issue

**Affected Packages**
List of affected packages:
  - webots_ros2_driver