### PR TITLE
Fix pep257 D407 Missing dashed underline after section

### DIFF
--- a/webots_ros2_core/webots_ros2_core/devices/camera_device.py
+++ b/webots_ros2_core/webots_ros2_core/devices/camera_device.py
@@ -36,13 +36,17 @@ class CameraDevice(SensorDevice):
     - Publishes raw image of type `sensor_msgs/Image`
     - Publishes intrinsic camera parameters of type `sensor_msgs/CameraInfo` (latched topic)
 
-    Args:
-        node (WebotsNode): The ROS2 node.
-        device_key (str): Unique identifier of the device used for configuration.
-        wb_device (Camera): Webots node of type Camera.
 
-    Kwargs:
-        params (dict): Inherited from `SensorDevice`
+    Parameters
+    ----------
+    node : WebotsNode
+      The ROS2 node.
+    device_key : str
+      Unique identifier of the device used for configuration.
+    wb_device : Camera
+      Webots node of type Camera.
+    params : dict
+      Inherited from `SensorDevice`
 
     """
 

--- a/webots_ros2_core/webots_ros2_core/devices/camera_device.py
+++ b/webots_ros2_core/webots_ros2_core/devices/camera_device.py
@@ -39,13 +39,13 @@ class CameraDevice(SensorDevice):
 
     Parameters
     ----------
-    node : WebotsNode
+    node: WebotsNode
       The ROS2 node.
-    device_key : str
+    device_key: str
       Unique identifier of the device used for configuration.
-    wb_device : Camera
+    wb_device: Camera
       Webots node of type Camera.
-    params : dict
+    params: dict
       Inherited from `SensorDevice`
 
     """


### PR DESCRIPTION
**Description**

PEP257 is failing on rolling with:

```
_________________________________ test_pep257 __________________________________
test/test_pep257.py:25: in test_pep257
    assert rc == 0, 'Found code style errors / warnings'
E   AssertionError: Found code style errors / warnings
E   assert 1 == 0
----------------------------- Captured stdout call -----------------------------
...
checking ./webots_ros2_core/devices/camera_device.py
./webots_ros2_core/devices/camera_device.py:30 in public class `CameraDevice`: D407: Missing dashed underline after section ('Args')
```

**Related Issues**
No related issue

**Affected Packages**
List of affected packages:
  - webots_ros2_core

**Additional context**
This error is showing up in [industrial_ci (main, rolling)](https://github.com/cyberbotics/webots_ros2/runs/6185995564?check_suite_focus=true) of https://github.com/cyberbotics/webots_ros2/pull/436

