### PR TITLE
Change call to spawner.py executable to spawner

### DIFF
--- a/webots_ros2_epuck/launch/robot_launch.py
+++ b/webots_ros2_epuck/launch/robot_launch.py
@@ -42,9 +42,11 @@ def generate_launch_description():
     controller_manager_timeout = ['--controller-manager-timeout', '50']
     controller_manager_prefix = 'python.exe' if os.name == 'nt' else ''
 
+    use_deprecated_spawner_py = 'ROS_DISTRO' in os.environ and os.environ['ROS_DISTRO'] == 'foxy'
+
     diffdrive_controller_spawner = Node(
         package='controller_manager',
-        executable='spawner',
+        executable='spawner' if not use_deprecated_spawner_py else 'spawner.py',
         output='screen',
         prefix=controller_manager_prefix,
         arguments=['diffdrive_controller'] + controller_manager_timeout,
@@ -55,7 +57,7 @@ def generate_launch_description():
 
     joint_state_broadcaster_spawner = Node(
         package='controller_manager',
-        executable='spawner',
+        executable='spawner' if not use_deprecated_spawner_py else 'spawner.py',
         output='screen',
         prefix=controller_manager_prefix,
         arguments=['joint_state_broadcaster'] + controller_manager_timeout,

--- a/webots_ros2_epuck/launch/robot_launch.py
+++ b/webots_ros2_epuck/launch/robot_launch.py
@@ -44,7 +44,7 @@ def generate_launch_description():
 
     diffdrive_controller_spawner = Node(
         package='controller_manager',
-        executable='spawner.py',
+        executable='spawner',
         output='screen',
         prefix=controller_manager_prefix,
         arguments=['diffdrive_controller'] + controller_manager_timeout,
@@ -55,7 +55,7 @@ def generate_launch_description():
 
     joint_state_broadcaster_spawner = Node(
         package='controller_manager',
-        executable='spawner.py',
+        executable='spawner',
         output='screen',
         prefix=controller_manager_prefix,
         arguments=['joint_state_broadcaster'] + controller_manager_timeout,

--- a/webots_ros2_tiago/launch/robot_launch.py
+++ b/webots_ros2_tiago/launch/robot_launch.py
@@ -51,9 +51,11 @@ def generate_launch_description():
     controller_manager_timeout = ['--controller-manager-timeout', '50']
     controller_manager_prefix = 'python.exe' if os.name == 'nt' else ''
 
+    use_deprecated_spawner_py = 'ROS_DISTRO' in os.environ and os.environ['ROS_DISTRO'] == 'foxy'
+
     diffdrive_controller_spawner = Node(
         package='controller_manager',
-        executable='spawner',
+        executable='spawner' if not use_deprecated_spawner_py else 'spawner.py',
         output='screen',
         prefix=controller_manager_prefix,
         arguments=['diffdrive_controller'] + controller_manager_timeout,
@@ -61,7 +63,7 @@ def generate_launch_description():
 
     joint_state_broadcaster_spawner = Node(
         package='controller_manager',
-        executable='spawner',
+        executable='spawner' if not use_deprecated_spawner_py else 'spawner.py',
         output='screen',
         prefix=controller_manager_prefix,
         arguments=['joint_state_broadcaster'] + controller_manager_timeout,

--- a/webots_ros2_tiago/launch/robot_launch.py
+++ b/webots_ros2_tiago/launch/robot_launch.py
@@ -53,7 +53,7 @@ def generate_launch_description():
 
     diffdrive_controller_spawner = Node(
         package='controller_manager',
-        executable='spawner.py',
+        executable='spawner',
         output='screen',
         prefix=controller_manager_prefix,
         arguments=['diffdrive_controller'] + controller_manager_timeout,
@@ -61,7 +61,7 @@ def generate_launch_description():
 
     joint_state_broadcaster_spawner = Node(
         package='controller_manager',
-        executable='spawner.py',
+        executable='spawner',
         output='screen',
         prefix=controller_manager_prefix,
         arguments=['joint_state_broadcaster'] + controller_manager_timeout,

--- a/webots_ros2_turtlebot/launch/robot_launch.py
+++ b/webots_ros2_turtlebot/launch/robot_launch.py
@@ -45,7 +45,7 @@ def generate_launch_description():
 
     diffdrive_controller_spawner = Node(
         package='controller_manager',
-        executable='spawner.py',
+        executable='spawner',
         output='screen',
         prefix=controller_manager_prefix,
         arguments=['diffdrive_controller'] + controller_manager_timeout,
@@ -53,7 +53,7 @@ def generate_launch_description():
 
     joint_state_broadcaster_spawner = Node(
         package='controller_manager',
-        executable='spawner.py',
+        executable='spawner',
         output='screen',
         prefix=controller_manager_prefix,
         arguments=['joint_state_broadcaster'] + controller_manager_timeout,

--- a/webots_ros2_turtlebot/launch/robot_launch.py
+++ b/webots_ros2_turtlebot/launch/robot_launch.py
@@ -43,9 +43,11 @@ def generate_launch_description():
     controller_manager_timeout = ['--controller-manager-timeout', '50']
     controller_manager_prefix = 'python.exe' if os.name == 'nt' else ''
 
+    use_deprecated_spawner_py = 'ROS_DISTRO' in os.environ and os.environ['ROS_DISTRO'] == 'foxy'
+
     diffdrive_controller_spawner = Node(
         package='controller_manager',
-        executable='spawner',
+        executable='spawner' if not use_deprecated_spawner_py else 'spawner.py',
         output='screen',
         prefix=controller_manager_prefix,
         arguments=['diffdrive_controller'] + controller_manager_timeout,
@@ -53,7 +55,7 @@ def generate_launch_description():
 
     joint_state_broadcaster_spawner = Node(
         package='controller_manager',
-        executable='spawner',
+        executable='spawner' if not use_deprecated_spawner_py else 'spawner.py',
         output='screen',
         prefix=controller_manager_prefix,
         arguments=['joint_state_broadcaster'] + controller_manager_timeout,

--- a/webots_ros2_universal_robot/launch/multirobot_launch.py
+++ b/webots_ros2_universal_robot/launch/multirobot_launch.py
@@ -71,28 +71,28 @@ def generate_launch_description():
     controller_manager_prefix = 'python.exe' if os.name == 'nt' else ''
     ur5e_trajectory_controller_spawner = Node(
         package='controller_manager',
-        executable='spawner.py',
+        executable='spawner',
         output='screen',
         prefix=controller_manager_prefix,
         arguments=['ur_joint_trajectory_controller', '-c', 'ur5e/controller_manager'] + controller_manager_timeout,
     )
     ur5e_joint_state_broadcaster_spawner = Node(
         package='controller_manager',
-        executable='spawner.py',
+        executable='spawner',
         output='screen',
         prefix=controller_manager_prefix,
         arguments=['ur_joint_state_broadcaster', '-c', 'ur5e/controller_manager'] + controller_manager_timeout,
     )
     abb_trajectory_controller_spawner = Node(
         package='controller_manager',
-        executable='spawner.py',
+        executable='spawner',
         output='screen',
         prefix=controller_manager_prefix,
         arguments=['abb_joint_trajectory_controller', '-c', 'abb/controller_manager'] + controller_manager_timeout,
     )
     abb_joint_state_broadcaster_spawner = Node(
         package='controller_manager',
-        executable='spawner.py',
+        executable='spawner',
         output='screen',
         prefix=controller_manager_prefix,
         arguments=['abb_joint_state_broadcaster', '-c', 'abb/controller_manager'] + controller_manager_timeout,

--- a/webots_ros2_universal_robot/launch/multirobot_launch.py
+++ b/webots_ros2_universal_robot/launch/multirobot_launch.py
@@ -69,30 +69,31 @@ def generate_launch_description():
 
     controller_manager_timeout = ['--controller-manager-timeout', '75']
     controller_manager_prefix = 'python.exe' if os.name == 'nt' else ''
+    use_deprecated_spawner_py = 'ROS_DISTRO' in os.environ and os.environ['ROS_DISTRO'] == 'foxy'
     ur5e_trajectory_controller_spawner = Node(
         package='controller_manager',
-        executable='spawner',
+        executable='spawner' if not use_deprecated_spawner_py else 'spawner.py',
         output='screen',
         prefix=controller_manager_prefix,
         arguments=['ur_joint_trajectory_controller', '-c', 'ur5e/controller_manager'] + controller_manager_timeout,
     )
     ur5e_joint_state_broadcaster_spawner = Node(
         package='controller_manager',
-        executable='spawner',
+        executable='spawner' if not use_deprecated_spawner_py else 'spawner.py',
         output='screen',
         prefix=controller_manager_prefix,
         arguments=['ur_joint_state_broadcaster', '-c', 'ur5e/controller_manager'] + controller_manager_timeout,
     )
     abb_trajectory_controller_spawner = Node(
         package='controller_manager',
-        executable='spawner',
+        executable='spawner' if not use_deprecated_spawner_py else 'spawner.py',
         output='screen',
         prefix=controller_manager_prefix,
         arguments=['abb_joint_trajectory_controller', '-c', 'abb/controller_manager'] + controller_manager_timeout,
     )
     abb_joint_state_broadcaster_spawner = Node(
         package='controller_manager',
-        executable='spawner',
+        executable='spawner' if not use_deprecated_spawner_py else 'spawner.py',
         output='screen',
         prefix=controller_manager_prefix,
         arguments=['abb_joint_state_broadcaster', '-c', 'abb/controller_manager'] + controller_manager_timeout,

--- a/webots_ros2_universal_robot/launch/robot_launch.py
+++ b/webots_ros2_universal_robot/launch/robot_launch.py
@@ -47,7 +47,7 @@ def generate_launch_description():
 
     trajectory_controller_spawner = Node(
         package='controller_manager',
-        executable='spawner.py',
+        executable='spawner',
         output='screen',
         prefix=controller_manager_prefix,
         arguments=['ur_joint_trajectory_controller'] + controller_manager_timeout,
@@ -55,7 +55,7 @@ def generate_launch_description():
 
     joint_state_broadcaster_spawner = Node(
         package='controller_manager',
-        executable='spawner.py',
+        executable='spawner',
         output='screen',
         prefix=controller_manager_prefix,
         arguments=['ur_joint_state_broadcaster'] + controller_manager_timeout,

--- a/webots_ros2_universal_robot/launch/robot_launch.py
+++ b/webots_ros2_universal_robot/launch/robot_launch.py
@@ -45,9 +45,11 @@ def generate_launch_description():
     controller_manager_timeout = ['--controller-manager-timeout', '100']
     controller_manager_prefix = 'python.exe' if os.name == 'nt' else ''
 
+    use_deprecated_spawner_py = 'ROS_DISTRO' in os.environ and os.environ['ROS_DISTRO'] == 'foxy'
+
     trajectory_controller_spawner = Node(
         package='controller_manager',
-        executable='spawner',
+        executable='spawner' if not use_deprecated_spawner_py else 'spawner.py',
         output='screen',
         prefix=controller_manager_prefix,
         arguments=['ur_joint_trajectory_controller'] + controller_manager_timeout,
@@ -55,7 +57,7 @@ def generate_launch_description():
 
     joint_state_broadcaster_spawner = Node(
         package='controller_manager',
-        executable='spawner',
+        executable='spawner' if not use_deprecated_spawner_py else 'spawner.py',
         output='screen',
         prefix=controller_manager_prefix,
         arguments=['ur_joint_state_broadcaster'] + controller_manager_timeout,


### PR DESCRIPTION
**Description**
``spawner.py`` was deprecated in ROS2 Galactic and removed in ROS2 Rolling in https://github.com/ros-controls/ros2_control/commit/ec0ec193cc09e449d5525e34e38040432fce5511.

It should be replaced by ``spawner``.
Galactic supports both ``spawner.py`` and ``spawner``, so we only have to deal with Foxy. (https://github.com/ros-controls/ros2_control/blob/67bf0a59a6908d9bfd385a05fdcfe3944c7bbb07/controller_manager/CMakeLists.txt#L58)

**Related Issues**
No related issue

**Affected Packages**
List of affected packages:
  - webots_ros2_epuck
  - webots_ros2_tiago
  - webots_ros2_turtle
  - webots_ros2_universal_robot

**Additional context**
This error is showing up in [industrial_ci (main, rolling)](https://github.com/cyberbotics/webots_ros2/runs/6185995564?check_suite_focus=true) of https://github.com/cyberbotics/webots_ros2/pull/436


