### PR TITLE
Fix master nightly

### DIFF
--- a/scripts/ci_after_init.bash
+++ b/scripts/ci_after_init.bash
@@ -15,7 +15,7 @@ WEBOTS_NIGHTLY_VERSION="nightly_${NIGHTLY_DATE}"
 
 apt update
 apt install -y wget dialog apt-utils psmisc lsb-release
-wget https://github.com/cyberbotics/webots/releases/download/${WEBOTS_RELEASE_VERSION}/webots_${WEBOTS_RELEASE_VERSION}_amd64.deb -O /tmp/webots.deb
+wget https://github.com/cyberbotics/webots/releases/download/R${WEBOTS_RELEASE_VERSION}/webots_${WEBOTS_RELEASE_VERSION}_amd64.deb -O /tmp/webots.deb
 apt install -y /tmp/webots.deb xvfb
 
 # OpenSSL patch for ubuntu 22

--- a/scripts/ci_after_init.bash
+++ b/scripts/ci_after_init.bash
@@ -15,7 +15,7 @@ WEBOTS_NIGHTLY_VERSION="nightly_${NIGHTLY_DATE}"
 
 apt update
 apt install -y wget dialog apt-utils psmisc lsb-release
-wget https://github.com/cyberbotics/webots/releases/download/${WEBOTS_NIGHTLY_VERSION}/webots_${WEBOTS_RELEASE_VERSION}_amd64.deb -O /tmp/webots.deb
+wget https://github.com/cyberbotics/webots/releases/download/${WEBOTS_RELEASE_VERSION}/webots_${WEBOTS_RELEASE_VERSION}_amd64.deb -O /tmp/webots.deb
 apt install -y /tmp/webots.deb xvfb
 
 # OpenSSL patch for ubuntu 22


### PR DESCRIPTION
**Description**

Due to the merge of webots develop into master, nightlies for R2022a are no longer created/available so we need to target R2022a itself.