### PR TITLE
Replace Windows compatibility with WSL

### DIFF
--- a/webots_ros2_driver/webots_ros2_driver/urdf_spawner.py
+++ b/webots_ros2_driver/webots_ros2_driver/urdf_spawner.py
@@ -31,7 +31,7 @@ def get_webots_driver_node(event, driver_node):
 class URDFSpawner(ExecuteProcess):
     def __init__(self, output='log', name=None, urdf_path=None, robot_description=None, relative_path_prefix=None, translation='0 0 0', rotation='0 0 1 0', normal=False, box_collision=False, init_pos=None, **kwargs):
         if is_wsl() and relative_path_prefix:
-            relative_path_prefix = subprocess.check_output(['wslpath', '-w', relative_path_prefix]).strip().decode("utf-8").replace('\\', '/')
+            relative_path_prefix = subprocess.check_output(['wslpath', '-w', relative_path_prefix]).strip().decode('utf-8').replace('\\', '/')
             
         message = '{robot: {'
 

--- a/webots_ros2_driver/webots_ros2_driver/urdf_spawner.py
+++ b/webots_ros2_driver/webots_ros2_driver/urdf_spawner.py
@@ -16,8 +16,10 @@
 
 """This process simply sends urdf information to the Spawner through a service."""
 
-from launch.actions import ExecuteProcess
+import subprocess
 
+from launch.actions import ExecuteProcess
+from webots_ros2_driver.utils import is_wsl
 
 def get_webots_driver_node(event, driver_node):
     """Return the driver node in case the service response is successful."""
@@ -28,6 +30,9 @@ def get_webots_driver_node(event, driver_node):
 
 class URDFSpawner(ExecuteProcess):
     def __init__(self, output='log', name=None, urdf_path=None, robot_description=None, relative_path_prefix=None, translation='0 0 0', rotation='0 0 1 0', normal=False, box_collision=False, init_pos=None, **kwargs):
+        if is_wsl() and relative_path_prefix:
+            relative_path_prefix = subprocess.check_output(['wslpath', '-w', relative_path_prefix]).strip().decode("utf-8").replace('\\', '/')
+            
         message = '{robot: {'
 
         if name:

--- a/webots_ros2_driver/webots_ros2_driver/utils.py
+++ b/webots_ros2_driver/webots_ros2_driver/utils.py
@@ -161,7 +161,7 @@ def __install_webots(installation_directory, isWSL):
     # Extract Webots archive
     if isWSL:
         print('Installing...')
-        subprocess.check_output(f'{archive_path} /SILENT', shell=True)
+        subprocess.check_output(f'{archive_path} /SILENT /ALLUSERS', shell=True)
         os.remove(archive_path)
         os.environ['WEBOTS_HOME'] = '/mnt/c/Program Files/Webots'
     else:
@@ -175,7 +175,7 @@ def __install_webots(installation_directory, isWSL):
 
 def handle_webots_installation(isWSL):
     target_version = WebotsVersion.target()
-    installation_directory = os.path.join(str(Path.home()), '.ros')
+    installation_directory = f'C:\\Program Files\\Webots' if isWSL else os.path.join(str(Path.home()), '.ros')
     webots_release_url = f'https://github.com/cyberbotics/webots/releases/tag/{target_version.short()}'
 
     print(
@@ -186,13 +186,13 @@ def handle_webots_installation(isWSL):
         f'`WEBOTS_HOME` environment variable.\n'
     )
 
-    location_text = '' if isWSL else f'in `{installation_directory}` '
+    location_text = f'in `{installation_directory}` '
     method = input(
         f'Do you want Webots {target_version} to be automatically installed {location_text}([Y]es/[N]o)?: ')
 
     if method.lower() == 'y':
         __install_webots(installation_directory, isWSL)
-        webots_path = get_webots_home()
+        webots_path = get_webots_home(isWSL)
         if webots_path is None:
             sys.exit(f'Failed to install Webots {target_version}')
     else:

--- a/webots_ros2_driver/webots_ros2_driver/utils.py
+++ b/webots_ros2_driver/webots_ros2_driver/utils.py
@@ -28,7 +28,7 @@ from pathlib import Path
 from platform import uname
 
 
-MINIMUM_VERSION_STR = 'R2023a'
+MINIMUM_VERSION_STR = 'R2022b'
 
 
 @functools.total_ordering

--- a/webots_ros2_driver/webots_ros2_driver/utils.py
+++ b/webots_ros2_driver/webots_ros2_driver/utils.py
@@ -134,11 +134,15 @@ def get_webots_home(show_warning=False):
     elif sys.platform == 'linux':
         paths = [
             '/usr/local/webots',                                    # Linux default install
-            '/snap/webots/current/usr/share/webots',                # Linux snap install
+            '/snap/webots/current/usr/share/webots'                 # Linux snap install
         ]
     elif sys.platform == 'darwin':
         paths = [
-            '/Applications/Webots.app',                             # macOS default install
+            '/Applications/Webots.app'                              # macOS default install
+        ]
+    elif sys.platform == 'win32':
+        paths = [
+            'C:\\Program Files\\Webots'
         ]
     # Add automatic installation path to pathes list
     paths.append(os.path.join(str(Path.home()), '.ros', 'webots' + minimum_version.short(), 'webots'))
@@ -201,7 +205,7 @@ def __install_webots(installation_directory):
 
 def handle_webots_installation():
     minimum_version = WebotsVersion.minimum()
-    installation_directory = f'C:\\Program Files\\Webots' if is_wsl() else os.path.join(str(Path.home()), '.ros')
+    installation_directory = f'C:\\Program Files\\Webots' if (is_wsl() or sys.platform == 'win32') else os.path.join(str(Path.home()), '.ros')
     webots_release_url = f'https://github.com/cyberbotics/webots/releases/tag/{minimum_version.short()}'
 
     print(
@@ -212,9 +216,8 @@ def handle_webots_installation():
         f'`WEBOTS_HOME` environment variable.\n'
     )
 
-    location_text = f'in `{installation_directory}` '
     method = input(
-        f'Do you want Webots {minimum_version} to be automatically installed {location_text}([Y]es/[N]o)?: ')
+        f'Do you want Webots {minimum_version} to be automatically installed in {installation_directory} ([Y]es/[N]o)?: ')
 
     if method.lower() == 'y':
         __install_webots(installation_directory)

--- a/webots_ros2_driver/webots_ros2_driver/utils.py
+++ b/webots_ros2_driver/webots_ros2_driver/utils.py
@@ -134,11 +134,15 @@ def get_webots_home(show_warning=False):
     elif sys.platform == 'linux':
         paths = [
             '/usr/local/webots',                                    # Linux default install
-            '/snap/webots/current/usr/share/webots',                # Linux snap install
+            '/snap/webots/current/usr/share/webots'                 # Linux snap install
         ]
     elif sys.platform == 'darwin':
         paths = [
-            '/Applications/Webots.app',                             # macOS default install
+            '/Applications/Webots.app'                              # macOS default install
+        ]
+    elif sys.platform == 'win32':
+        paths = [
+            'C:\\Program Files\\Webots'                             # Windows default install       
         ]
     # Add automatic installation path to pathes list
     paths.append(os.path.join(str(Path.home()), '.ros', 'webots' + minimum_version.short(), 'webots'))
@@ -201,7 +205,7 @@ def __install_webots(installation_directory):
 
 def handle_webots_installation():
     minimum_version = WebotsVersion.minimum()
-    installation_directory = f'C:\\Program Files\\Webots' if is_wsl() else os.path.join(str(Path.home()), '.ros')
+    installation_directory = f'C:\\Program Files\\Webots' if (is_wsl() or sys.platform == 'win32') else os.path.join(str(Path.home()), '.ros')
     webots_release_url = f'https://github.com/cyberbotics/webots/releases/tag/{minimum_version.short()}'
 
     print(
@@ -212,9 +216,8 @@ def handle_webots_installation():
         f'`WEBOTS_HOME` environment variable.\n'
     )
 
-    location_text = f'in `{installation_directory}` '
     method = input(
-        f'Do you want Webots {minimum_version} to be automatically installed {location_text}([Y]es/[N]o)?: ')
+        f'Do you want Webots {minimum_version} to be automatically installed in {installation_directory} ([Y]es/[N]o)?: ')
 
     if method.lower() == 'y':
         __install_webots(installation_directory)

--- a/webots_ros2_driver/webots_ros2_driver/utils.py
+++ b/webots_ros2_driver/webots_ros2_driver/utils.py
@@ -134,15 +134,11 @@ def get_webots_home(show_warning=False):
     elif sys.platform == 'linux':
         paths = [
             '/usr/local/webots',                                    # Linux default install
-            '/snap/webots/current/usr/share/webots'                 # Linux snap install
+            '/snap/webots/current/usr/share/webots',                # Linux snap install
         ]
     elif sys.platform == 'darwin':
         paths = [
-            '/Applications/Webots.app'                              # macOS default install
-        ]
-    elif sys.platform == 'win32':
-        paths = [
-            'C:\\Program Files\\Webots'
+            '/Applications/Webots.app',                             # macOS default install
         ]
     # Add automatic installation path to pathes list
     paths.append(os.path.join(str(Path.home()), '.ros', 'webots' + minimum_version.short(), 'webots'))
@@ -205,7 +201,7 @@ def __install_webots(installation_directory):
 
 def handle_webots_installation():
     minimum_version = WebotsVersion.minimum()
-    installation_directory = f'C:\\Program Files\\Webots' if (is_wsl() or sys.platform == 'win32') else os.path.join(str(Path.home()), '.ros')
+    installation_directory = f'C:\\Program Files\\Webots' if is_wsl() else os.path.join(str(Path.home()), '.ros')
     webots_release_url = f'https://github.com/cyberbotics/webots/releases/tag/{minimum_version.short()}'
 
     print(
@@ -216,8 +212,9 @@ def handle_webots_installation():
         f'`WEBOTS_HOME` environment variable.\n'
     )
 
+    location_text = f'in `{installation_directory}` '
     method = input(
-        f'Do you want Webots {minimum_version} to be automatically installed in {installation_directory} ([Y]es/[N]o)?: ')
+        f'Do you want Webots {minimum_version} to be automatically installed {location_text}([Y]es/[N]o)?: ')
 
     if method.lower() == 'y':
         __install_webots(installation_directory)

--- a/webots_ros2_driver/webots_ros2_driver/utils.py
+++ b/webots_ros2_driver/webots_ros2_driver/utils.py
@@ -28,7 +28,7 @@ from pathlib import Path
 from platform import uname
 
 
-TARGET_VERSION_STR = 'R2022b'
+TARGET_VERSION_STR = 'R2023a'
 
 
 @functools.total_ordering

--- a/webots_ros2_driver/webots_ros2_driver/utils.py
+++ b/webots_ros2_driver/webots_ros2_driver/utils.py
@@ -28,6 +28,7 @@ from pathlib import Path
 from platform import uname
 
 
+# The minimal version should be the last stable release of Webots (both on master and develop branches)
 MINIMUM_VERSION_STR = 'R2022b'
 
 

--- a/webots_ros2_driver/webots_ros2_driver/utils.py
+++ b/webots_ros2_driver/webots_ros2_driver/utils.py
@@ -134,7 +134,7 @@ def __get_webots_home(target_version, condition='ge'):
 
     # Use the 'which' command (Linux and Mac)
     try:
-        where_command = 'where' if sys.platform == 'win32' else 'which'
+        where_command = 'which'
         path = os.path.split(os.path.abspath(subprocess.check_output([where_command, 'webots'])))[0]
         path = path.decode('utf-8')
         if os.path.isdir(path) and version_condition(WebotsVersion.from_path(path), target_version):
@@ -153,7 +153,8 @@ def __get_webots_home(target_version, condition='ge'):
         '/snap/webots/current/usr/share/webots',                # Linux snap install
         '/Applications/Webots.app',                             # macOS default install
         'C:\\Program Files\\Webots',                            # Windows default install
-        os.getenv('LOCALAPPDATA', '') + '\\Programs\\Webots'    # Windows user install
+        os.getenv('LOCALAPPDATA', '') + '\\Programs\\Webots',   # Windows user 
+        '/mnt/c/Program Files/Webots'                           # WSL default Windows install
     ]
     if target_version is not None:
         paths.append(os.path.join(str(Path.home()), '.ros', 'webots' + target_version.short(), 'webots'))

--- a/webots_ros2_driver/webots_ros2_driver/utils.py
+++ b/webots_ros2_driver/webots_ros2_driver/utils.py
@@ -79,6 +79,28 @@ class WebotsVersion:
     def short(self):
         return self.version.replace('revision ', 'rev').replace(' ', '-')
 
+def get_wsl_ip_address():
+    try:
+        file = open('/etc/resolv.conf', 'r')
+    except IOError:
+        # /etc/resolv.conf doesn't exist, can't be read, etc.
+        # Use the default resolver configuration.
+        return '127.0.0.1'
+    try:
+        for line in file:
+            if len(line) == 0 or line[0] == '#' or line[0] == ';':
+                continue
+            tokens = line.split()
+            if len(tokens) == 0:
+                continue
+            if tokens[0] == 'nameserver':
+                file.close()
+                if len(tokens[1]) == 0:
+                    return '127.0.0.1'
+                return tokens[1]
+    finally:
+        file.close()
+    
 
 def get_webots_home(isWSL, show_warning=False):
     def version_equal(found, target):

--- a/webots_ros2_driver/webots_ros2_driver/webots_launcher.py
+++ b/webots_ros2_driver/webots_ros2_driver/webots_launcher.py
@@ -49,11 +49,14 @@ class _ConditionalSubstitution(Substitution):
 
 class WebotsLauncher(ExecuteProcess):
     def __init__(self, output='screen', world=None, gui=True, mode='realtime', stream=False, **kwargs):
+        if sys.platform == 'win32':
+            sys.exit(f'Windows is not supported by the webots_ros2 package.')
         isWSL = 'microsoft-standard' in uname().release
+
         # Find Webots executable
         webots_path = get_webots_home(show_warning=True)
         if webots_path is None:
-            handle_webots_installation()
+            handle_webots_installation(isWSL)
             webots_path = get_webots_home()
         if isWSL:
             webots_path = os.path.join(webots_path, 'msys64', 'mingw64', 'bin', 'webots.exe')

--- a/webots_ros2_driver/webots_ros2_driver/webots_launcher.py
+++ b/webots_ros2_driver/webots_ros2_driver/webots_launcher.py
@@ -160,9 +160,7 @@ class WebotsLauncher(ExecuteProcess):
 
 class Ros2SupervisorLauncher(Node):
     def __init__(self, output='screen', respawn=True, **kwargs):
-        controller_url = ''
-        if is_wsl():
-            controller_url = 'tcp://' + get_wsl_ip_address() + ':1234/'
+        controller_url = 'tcp://' + get_wsl_ip_address() + ':1234/' if is_wsl() else ''
 
         # Launch the Ros2Supervisor node
         super().__init__(

--- a/webots_ros2_driver/webots_ros2_driver/webots_launcher.py
+++ b/webots_ros2_driver/webots_ros2_driver/webots_launcher.py
@@ -72,7 +72,7 @@ class WebotsLauncher(ExecuteProcess):
             world = TextSubstitution(text=self.__world_copy.name)
 
         if self.__is_wsl:
-            wsl_tmp_path = subprocess.check_output(['wslpath', '-w', self.__world_copy.name]).strip().decode("utf-8")
+            wsl_tmp_path = subprocess.check_output(['wslpath', '-w', self.__world_copy.name]).strip().decode('utf-8')
             world = TextSubstitution(text=wsl_tmp_path)
 
         no_rendering = _ConditionalSubstitution(condition=gui, false_value='--no-rendering')

--- a/webots_ros2_driver/webots_ros2_driver/webots_launcher.py
+++ b/webots_ros2_driver/webots_ros2_driver/webots_launcher.py
@@ -51,7 +51,7 @@ class _ConditionalSubstitution(Substitution):
 class WebotsLauncher(ExecuteProcess):
     def __init__(self, output='screen', world=None, gui=True, mode='realtime', stream=False, **kwargs):
         if sys.platform == 'win32':
-            sys.exit(f'Windows is not supported by the webots_ros2 package.')
+            print('WARNING: Windows compatibility will be deprecated soon. Please run webots_ros2 in a WSL2 envrionment instead.')
         self.__is_wsl = is_wsl()
 
         # Find Webots executable
@@ -59,7 +59,7 @@ class WebotsLauncher(ExecuteProcess):
         if webots_path is None:
             handle_webots_installation()
             webots_path = get_webots_home()
-        if self.__is_wsl:
+        if self.__is_wsl or sys.platform == 'win32':
             webots_path = os.path.join(webots_path, 'msys64', 'mingw64', 'bin', 'webots.exe')
         else:
             webots_path = os.path.join(webots_path, 'webots')

--- a/webots_ros2_driver/webots_ros2_driver/webots_launcher.py
+++ b/webots_ros2_driver/webots_ros2_driver/webots_launcher.py
@@ -54,10 +54,10 @@ class WebotsLauncher(ExecuteProcess):
         isWSL = 'microsoft-standard' in uname().release
 
         # Find Webots executable
-        webots_path = get_webots_home(show_warning=True)
+        webots_path = get_webots_home(isWSL, show_warning=True)
         if webots_path is None:
             handle_webots_installation(isWSL)
-            webots_path = get_webots_home()
+            webots_path = get_webots_home(isWSL)
         if isWSL:
             webots_path = os.path.join(webots_path, 'msys64', 'mingw64', 'bin', 'webots.exe')
         else:

--- a/webots_ros2_driver/webots_ros2_driver/webots_launcher.py
+++ b/webots_ros2_driver/webots_ros2_driver/webots_launcher.py
@@ -51,7 +51,7 @@ class _ConditionalSubstitution(Substitution):
 class WebotsLauncher(ExecuteProcess):
     def __init__(self, output='screen', world=None, gui=True, mode='realtime', stream=False, **kwargs):
         if sys.platform == 'win32':
-            print('WARNING: Windows compatibility will be deprecated soon. Please run webots_ros2 in a WSL2 envrionment instead.')
+            sys.exit(f'Windows is not supported by the webots_ros2 package.')
         self.__is_wsl = is_wsl()
 
         # Find Webots executable
@@ -59,7 +59,7 @@ class WebotsLauncher(ExecuteProcess):
         if webots_path is None:
             handle_webots_installation()
             webots_path = get_webots_home()
-        if self.__is_wsl or sys.platform == 'win32':
+        if self.__is_wsl:
             webots_path = os.path.join(webots_path, 'msys64', 'mingw64', 'bin', 'webots.exe')
         else:
             webots_path = os.path.join(webots_path, 'webots')

--- a/webots_ros2_driver/webots_ros2_driver/webots_launcher.py
+++ b/webots_ros2_driver/webots_ros2_driver/webots_launcher.py
@@ -32,7 +32,8 @@ from launch.substitutions import TextSubstitution
 from launch.substitutions.path_join_substitution import PathJoinSubstitution
 
 from webots_ros2_driver.utils import (get_webots_home,
-                                      handle_webots_installation)
+                                      handle_webots_installation,
+                                      get_wsl_ip_address)
 
 
 class _ConditionalSubstitution(Substitution):
@@ -51,14 +52,14 @@ class WebotsLauncher(ExecuteProcess):
     def __init__(self, output='screen', world=None, gui=True, mode='realtime', stream=False, **kwargs):
         if sys.platform == 'win32':
             sys.exit(f'Windows is not supported by the webots_ros2 package.')
-        isWSL = 'microsoft-standard' in uname().release
+        self._isWSL = 'microsoft-standard' in uname().release
 
         # Find Webots executable
-        webots_path = get_webots_home(isWSL, show_warning=True)
+        webots_path = get_webots_home(self._isWSL, show_warning=True)
         if webots_path is None:
-            handle_webots_installation(isWSL)
-            webots_path = get_webots_home(isWSL)
-        if isWSL:
+            handle_webots_installation(self._isWSL)
+            webots_path = get_webots_home(self._isWSL)
+        if self._isWSL:
             webots_path = os.path.join(webots_path, 'msys64', 'mingw64', 'bin', 'webots.exe')
         else:
             webots_path = os.path.join(webots_path, 'webots')
@@ -70,7 +71,7 @@ class WebotsLauncher(ExecuteProcess):
         if not isinstance(world, Substitution):
             world = TextSubstitution(text=self.__world_copy.name)
 
-        if isWSL:
+        if self._isWSL:
             wsl_tmp_path = subprocess.check_output(['wslpath', '-w', self.__world_copy.name]).strip().decode("utf-8")
             world = TextSubstitution(text=wsl_tmp_path)
 
@@ -158,13 +159,17 @@ class WebotsLauncher(ExecuteProcess):
 
 
 class Ros2SupervisorLauncher(Node):
-    def __init__(self, output='screen', respawn=True, **kwargs):
+    def __init__(self, output='screen', respawn=True, isWSL=False, **kwargs):
+        controller_url = ''
+        if isWSL:
+            controller_url = 'tcp://' + get_wsl_ip_address() + ':1234/'
+
         # Launch the Ros2Supervisor node
         super().__init__(
             package='webots_ros2_driver',
             executable='ros2_supervisor.py',
             output=output,
-            additional_env={'WEBOTS_CONTROLLER_URL': 'Ros2Supervisor'},
+            additional_env={'WEBOTS_CONTROLLER_URL': controller_url + 'Ros2Supervisor'},
             respawn=respawn,
             **kwargs
         )

--- a/webots_ros2_epuck/launch/robot_launch.py
+++ b/webots_ros2_epuck/launch/robot_launch.py
@@ -40,9 +40,7 @@ def generate_launch_description():
         world=PathJoinSubstitution([package_dir, 'worlds', world])
     )
 
-    controller_url = ''
-    if is_wsl():
-        controller_url = 'tcp://' + get_wsl_ip_address() + ':1234/'
+    controller_url = 'tcp://' + get_wsl_ip_address() + ':1234/' if is_wsl() else ''
 
     ros2_supervisor = Ros2SupervisorLauncher()
 

--- a/webots_ros2_epuck/launch/robot_launch.py
+++ b/webots_ros2_epuck/launch/robot_launch.py
@@ -26,7 +26,7 @@ from launch_ros.actions import Node
 from launch import LaunchDescription
 from ament_index_python.packages import get_package_share_directory
 from webots_ros2_driver.webots_launcher import WebotsLauncher, Ros2SupervisorLauncher
-from webots_ros2_driver.utils import (get_wsl_ip_address)
+from webots_ros2_driver.utils import get_wsl_ip_address, is_wsl
 
 
 def generate_launch_description():
@@ -41,10 +41,10 @@ def generate_launch_description():
     )
 
     controller_url = ''
-    if webots._isWSL:
+    if is_wsl():
         controller_url = 'tcp://' + get_wsl_ip_address() + ':1234/'
 
-    ros2_supervisor = Ros2SupervisorLauncher(isWSL=webots._isWSL)
+    ros2_supervisor = Ros2SupervisorLauncher()
 
     controller_manager_timeout = ['--controller-manager-timeout', '50']
     controller_manager_prefix = 'python.exe' if os.name == 'nt' else ''

--- a/webots_ros2_epuck/launch/robot_launch.py
+++ b/webots_ros2_epuck/launch/robot_launch.py
@@ -26,6 +26,7 @@ from launch_ros.actions import Node
 from launch import LaunchDescription
 from ament_index_python.packages import get_package_share_directory
 from webots_ros2_driver.webots_launcher import WebotsLauncher, Ros2SupervisorLauncher
+from webots_ros2_driver.utils import (get_wsl_ip_address)
 
 
 def generate_launch_description():
@@ -39,7 +40,11 @@ def generate_launch_description():
         world=PathJoinSubstitution([package_dir, 'worlds', world])
     )
 
-    ros2_supervisor = Ros2SupervisorLauncher()
+    controller_url = ''
+    if webots._isWSL:
+        controller_url = 'tcp://' + get_wsl_ip_address() + ':1234/'
+
+    ros2_supervisor = Ros2SupervisorLauncher(isWSL=webots._isWSL)
 
     controller_manager_timeout = ['--controller-manager-timeout', '50']
     controller_manager_prefix = 'python.exe' if os.name == 'nt' else ''
@@ -76,7 +81,7 @@ def generate_launch_description():
         package='webots_ros2_driver',
         executable='driver',
         output='screen',
-        additional_env={'WEBOTS_CONTROLLER_URL': 'epuck'},
+        additional_env={'WEBOTS_CONTROLLER_URL': controller_url + 'epuck'},
         parameters=[
             {'robot_description': robot_description,
              'use_sim_time': use_sim_time,

--- a/webots_ros2_mavic/launch/robot_launch.py
+++ b/webots_ros2_mavic/launch/robot_launch.py
@@ -26,6 +26,7 @@ from launch_ros.actions import Node
 from launch import LaunchDescription
 from ament_index_python.packages import get_package_share_directory
 from webots_ros2_driver.webots_launcher import WebotsLauncher, Ros2SupervisorLauncher
+from webots_ros2_driver.utils import get_wsl_ip_address, is_wsl
 
 
 def generate_launch_description():
@@ -37,13 +38,17 @@ def generate_launch_description():
         world=PathJoinSubstitution([package_dir, 'worlds', world])
     )
 
+    controller_url = ''
+    if is_wsl():
+        controller_url = 'tcp://' + get_wsl_ip_address() + ':1234/'
+
     ros2_supervisor = Ros2SupervisorLauncher()
 
     mavic_driver = Node(
         package='webots_ros2_driver',
         executable='driver',
         output='screen',
-        additional_env={'WEBOTS_CONTROLLER_URL': 'Mavic_2_PRO'},
+        additional_env={'WEBOTS_CONTROLLER_URL': controller_url + 'Mavic_2_PRO'},
         parameters=[
             {'robot_description': robot_description},
         ]

--- a/webots_ros2_mavic/launch/robot_launch.py
+++ b/webots_ros2_mavic/launch/robot_launch.py
@@ -38,9 +38,7 @@ def generate_launch_description():
         world=PathJoinSubstitution([package_dir, 'worlds', world])
     )
 
-    controller_url = ''
-    if is_wsl():
-        controller_url = 'tcp://' + get_wsl_ip_address() + ':1234/'
+    controller_url = 'tcp://' + get_wsl_ip_address() + ':1234/' if is_wsl() else ''
 
     ros2_supervisor = Ros2SupervisorLauncher()
 

--- a/webots_ros2_tesla/launch/robot_launch.py
+++ b/webots_ros2_tesla/launch/robot_launch.py
@@ -38,9 +38,7 @@ def generate_launch_description():
         world=PathJoinSubstitution([package_dir, 'worlds', world])
     )
 
-    controller_url = ''
-    if is_wsl():
-        controller_url = 'tcp://' + get_wsl_ip_address() + ':1234/'
+    controller_url = 'tcp://' + get_wsl_ip_address() + ':1234/' if is_wsl() else ''
 
     ros2_supervisor = Ros2SupervisorLauncher()
 

--- a/webots_ros2_tesla/launch/robot_launch.py
+++ b/webots_ros2_tesla/launch/robot_launch.py
@@ -26,6 +26,7 @@ from launch import LaunchDescription
 from ament_index_python.packages import get_package_share_directory
 from launch_ros.actions import Node
 from webots_ros2_driver.webots_launcher import WebotsLauncher, Ros2SupervisorLauncher
+from webots_ros2_driver.utils import get_wsl_ip_address, is_wsl
 
 
 def generate_launch_description():
@@ -37,13 +38,17 @@ def generate_launch_description():
         world=PathJoinSubstitution([package_dir, 'worlds', world])
     )
 
+    controller_url = ''
+    if is_wsl():
+        controller_url = 'tcp://' + get_wsl_ip_address() + ':1234/'
+
     ros2_supervisor = Ros2SupervisorLauncher()
 
     tesla_driver = Node(
         package='webots_ros2_driver',
         executable='driver',
         output='screen',
-        additional_env={'WEBOTS_CONTROLLER_URL': 'vehicle'},
+        additional_env={'WEBOTS_CONTROLLER_URL': controller_url + 'vehicle'},
         parameters=[
             {'robot_description': robot_description},
         ]

--- a/webots_ros2_tests/test/test_system_driver.py
+++ b/webots_ros2_tests/test/test_system_driver.py
@@ -35,6 +35,7 @@ import launch_testing.actions
 from ament_index_python.packages import get_package_share_directory
 from webots_ros2_driver.webots_launcher import WebotsLauncher
 from webots_ros2_tests.utils import TestWebots, initialize_webots_test
+from webots_ros2_driver.utils import get_wsl_ip_address, is_wsl
 
 
 @pytest.mark.rostest
@@ -50,11 +51,15 @@ def generate_test_description():
         mode='fast'
     )
 
+    controller_url = ''
+    if is_wsl():
+        controller_url = 'tcp://' + get_wsl_ip_address() + ':1234/'
+
     ros2_supervisor = Node(
         package='webots_ros2_driver',
         executable='ros2_supervisor.py',
         output='screen',
-        additional_env={'WEBOTS_CONTROLLER_URL': 'Ros2Supervisor'},
+        additional_env={'WEBOTS_CONTROLLER_URL': controller_url + 'Ros2Supervisor'},
         respawn=True,
     )
 
@@ -62,7 +67,7 @@ def generate_test_description():
         package='webots_ros2_driver',
         executable='driver',
         output='screen',
-        additional_env={'WEBOTS_CONTROLLER_URL': 'Pioneer_3_AT'},
+        additional_env={'WEBOTS_CONTROLLER_URL': controller_url + 'Pioneer_3_AT'},
         parameters=[{'robot_description': robot_description, 'use_sim_time': True}]
     )
 

--- a/webots_ros2_tests/test/test_system_driver.py
+++ b/webots_ros2_tests/test/test_system_driver.py
@@ -51,9 +51,7 @@ def generate_test_description():
         mode='fast'
     )
 
-    controller_url = ''
-    if is_wsl():
-        controller_url = 'tcp://' + get_wsl_ip_address() + ':1234/'
+    controller_url = 'tcp://' + get_wsl_ip_address() + ':1234/' if is_wsl() else ''
 
     ros2_supervisor = Node(
         package='webots_ros2_driver',

--- a/webots_ros2_tiago/launch/robot_launch.py
+++ b/webots_ros2_tiago/launch/robot_launch.py
@@ -28,6 +28,7 @@ from ament_index_python.packages import get_package_share_directory, get_package
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.actions import IncludeLaunchDescription
 from webots_ros2_driver.webots_launcher import WebotsLauncher, Ros2SupervisorLauncher
+from webots_ros2_driver.utils import get_wsl_ip_address, is_wsl
 
 
 def generate_launch_description():
@@ -47,6 +48,10 @@ def generate_launch_description():
         world=PathJoinSubstitution([package_dir, 'worlds', world]),
         mode=mode
     )
+
+    controller_url = ''
+    if is_wsl():
+        controller_url = 'tcp://' + get_wsl_ip_address() + ':1234/'
 
     ros2_supervisor = Ros2SupervisorLauncher()
 
@@ -79,7 +84,7 @@ def generate_launch_description():
         package='webots_ros2_driver',
         executable='driver',
         output='screen',
-        additional_env={'WEBOTS_CONTROLLER_URL': 'Tiago_Iron'},
+        additional_env={'WEBOTS_CONTROLLER_URL': controller_url + 'Tiago_Iron'},
         parameters=[
             {'robot_description': robot_description,
              'use_sim_time': use_sim_time,

--- a/webots_ros2_tiago/launch/robot_launch.py
+++ b/webots_ros2_tiago/launch/robot_launch.py
@@ -49,9 +49,7 @@ def generate_launch_description():
         mode=mode
     )
 
-    controller_url = ''
-    if is_wsl():
-        controller_url = 'tcp://' + get_wsl_ip_address() + ':1234/'
+    controller_url = 'tcp://' + get_wsl_ip_address() + ':1234/' if is_wsl() else ''
 
     ros2_supervisor = Ros2SupervisorLauncher()
 

--- a/webots_ros2_turtlebot/launch/robot_launch.py
+++ b/webots_ros2_turtlebot/launch/robot_launch.py
@@ -40,9 +40,7 @@ def generate_launch_description():
         world=PathJoinSubstitution([package_dir, 'worlds', world])
     )
 
-    controller_url = ''
-    if is_wsl():
-        controller_url = 'tcp://' + get_wsl_ip_address() + ':1234/'
+    controller_url = 'tcp://' + get_wsl_ip_address() + ':1234/' if is_wsl() else ''
 
     ros2_supervisor = Ros2SupervisorLauncher()
 

--- a/webots_ros2_turtlebot/launch/robot_launch.py
+++ b/webots_ros2_turtlebot/launch/robot_launch.py
@@ -26,6 +26,7 @@ from launch_ros.actions import Node
 import launch
 from ament_index_python.packages import get_package_share_directory
 from webots_ros2_driver.webots_launcher import WebotsLauncher, Ros2SupervisorLauncher
+from webots_ros2_driver.utils import get_wsl_ip_address, is_wsl
 
 
 def generate_launch_description():
@@ -38,6 +39,10 @@ def generate_launch_description():
     webots = WebotsLauncher(
         world=PathJoinSubstitution([package_dir, 'worlds', world])
     )
+
+    controller_url = ''
+    if is_wsl():
+        controller_url = 'tcp://' + get_wsl_ip_address() + ':1234/'
 
     ros2_supervisor = Ros2SupervisorLauncher()
 
@@ -71,7 +76,7 @@ def generate_launch_description():
         package='webots_ros2_driver',
         executable='driver',
         output='screen',
-        additional_env={'WEBOTS_CONTROLLER_URL': 'TurtleBot3Burger'},
+        additional_env={'WEBOTS_CONTROLLER_URL': controller_url + 'TurtleBot3Burger'},
         parameters=[
             {'robot_description': robot_description,
              'use_sim_time': use_sim_time,

--- a/webots_ros2_universal_robot/launch/multirobot_launch.py
+++ b/webots_ros2_universal_robot/launch/multirobot_launch.py
@@ -28,6 +28,7 @@ from launch.substitutions.path_join_substitution import PathJoinSubstitution
 from launch_ros.actions import Node
 from webots_ros2_driver.urdf_spawner import URDFSpawner, get_webots_driver_node
 from webots_ros2_driver.webots_launcher import WebotsLauncher, Ros2SupervisorLauncher
+from webots_ros2_driver.utils import get_wsl_ip_address, is_wsl
 
 
 PACKAGE_NAME = 'webots_ros2_universal_robot'
@@ -41,6 +42,10 @@ def get_ros2_nodes(*args):
     abb_description = pathlib.Path(os.path.join(package_dir, 'resource', 'webots_abb_description.urdf')).read_text()
     ur5e_control_params = os.path.join(package_dir, 'resource', 'ros2_control_config.yaml')
     abb_control_params = os.path.join(package_dir, 'resource', 'ros2_control_abb_config.yaml')
+
+    controller_url = ''
+    if is_wsl():
+        controller_url = 'tcp://' + get_wsl_ip_address() + ':1234/'
 
     # Define your URDF robots here
     # The name of an URDF robot has to match the WEBOTS_CONTROLLER_URL of the driver node
@@ -63,7 +68,7 @@ def get_ros2_nodes(*args):
         package='webots_ros2_driver',
         executable='driver',
         output='screen',
-        additional_env={'WEBOTS_CONTROLLER_URL': 'UR5e'},
+        additional_env={'WEBOTS_CONTROLLER_URL': controller_url + 'UR5e'},
         namespace='ur5e',
         parameters=[
             {'robot_description': ur5e_description},
@@ -77,7 +82,7 @@ def get_ros2_nodes(*args):
         package='webots_ros2_driver',
         executable='driver',
         output='screen',
-        additional_env={'WEBOTS_CONTROLLER_URL': 'abbirb4600'},
+        additional_env={'WEBOTS_CONTROLLER_URL': controller_url + 'abbirb4600'},
         namespace='abb',
         parameters=[
             {'robot_description': abb_description},

--- a/webots_ros2_universal_robot/launch/multirobot_launch.py
+++ b/webots_ros2_universal_robot/launch/multirobot_launch.py
@@ -43,9 +43,7 @@ def get_ros2_nodes(*args):
     ur5e_control_params = os.path.join(package_dir, 'resource', 'ros2_control_config.yaml')
     abb_control_params = os.path.join(package_dir, 'resource', 'ros2_control_abb_config.yaml')
 
-    controller_url = ''
-    if is_wsl():
-        controller_url = 'tcp://' + get_wsl_ip_address() + ':1234/'
+    controller_url = 'tcp://' + get_wsl_ip_address() + ':1234/' if is_wsl() else ''
 
     # Define your URDF robots here
     # The name of an URDF robot has to match the WEBOTS_CONTROLLER_URL of the driver node

--- a/webots_ros2_universal_robot/launch/robot_launch/robot_nodes_launch.py
+++ b/webots_ros2_universal_robot/launch/robot_launch/robot_nodes_launch.py
@@ -35,9 +35,7 @@ def generate_launch_description():
     robot_description = pathlib.Path(ur5e_urdf_path).read_text()
     ros2_control_params = os.path.join(package_dir, 'resource', 'ros2_control_config.yaml')
 
-    controller_url = ''
-    if is_wsl():
-        controller_url = 'tcp://' + get_wsl_ip_address() + ':1234/'
+    controller_url = 'tcp://' + get_wsl_ip_address() + ':1234/' if is_wsl() else ''
 
     # Define your URDF robots here
     # The name of an URDF robot has to match the WEBOTS_CONTROLLER_URL of the driver node

--- a/webots_ros2_universal_robot/launch/robot_launch/robot_nodes_launch.py
+++ b/webots_ros2_universal_robot/launch/robot_launch/robot_nodes_launch.py
@@ -23,6 +23,7 @@ from launch_ros.actions import Node
 from launch import LaunchDescription
 from ament_index_python.packages import get_package_share_directory
 from webots_ros2_driver.urdf_spawner import URDFSpawner, get_webots_driver_node
+from webots_ros2_driver.utils import get_wsl_ip_address, is_wsl
 
 
 PACKAGE_NAME = 'webots_ros2_universal_robot'
@@ -33,6 +34,10 @@ def generate_launch_description():
     ur5e_urdf_path = os.path.join(package_dir, 'resource', 'ur5e_with_gripper.urdf')
     robot_description = pathlib.Path(ur5e_urdf_path).read_text()
     ros2_control_params = os.path.join(package_dir, 'resource', 'ros2_control_config.yaml')
+
+    controller_url = ''
+    if is_wsl():
+        controller_url = 'tcp://' + get_wsl_ip_address() + ':1234/'
 
     # Define your URDF robots here
     # The name of an URDF robot has to match the WEBOTS_CONTROLLER_URL of the driver node
@@ -53,7 +58,7 @@ def generate_launch_description():
         package='webots_ros2_driver',
         executable='driver',
         output='screen',
-        additional_env={'WEBOTS_CONTROLLER_URL': 'UR5e'},
+        additional_env={'WEBOTS_CONTROLLER_URL': controller_url + 'UR5e'},
         parameters=[
             {'robot_description': robot_description},
             {'use_sim_time': True},


### PR DESCRIPTION
Currently, the documentation and tutorials detail how to use `webots_ros2` on Windows and the package officially supports installation on this platform. However, using ROS2 outside of a Linux environment is not trivial and many other distributed packages are not maintained for macOS or Windows.

This PR deprecates the compatibility with Windows, but adds the possibility to run the package in WSL (Windows Subsystem for Linux). This way Webots still runs on Windows, while the whole ROS2 part can be run in a Linux environment, which greatly increases the simplicity of package maintenance, usage and the possibility to use other distributed packages. In short, the experience of Windows users is greatly improved and simplified.

In addition, this PR changes the way Webots is searched in the system at launch. The order of priority is as follows:
- Installation contained in ROS2_WEBOTS_HOME, regardless of version.
- Installation contained in WEBOTS_HOME, regardless of version.
- Search in the default installation folders (compatible version only):
  - `C:\Program Files\Webots` on the WSL system
  - `/usr/local/webots` and `/snap/webots/current/usr/share/webots` on Linux
  - `/Applications/Webots.app` on macOS
- Suggest an automatic installation of the compatible version of Webots in `~/.ros/webots`.

Wiki and documentation updates:
* [Getting Started](https://github.com/cyberbotics/webots_ros2/wiki/Getting-Started).
* [Complete Installation Guide](https://github.com/cyberbotics/webots_ros2/wiki/Complete-Installation-Guide).
* [ROS2 documentation](https://github.com/cyberbotics/ros2_documentation/pull/2).