### PR TITLE
Automatic libcontroller sync

### DIFF
--- a/.github/workflows/libcontroller_updater.yml
+++ b/.github/workflows/libcontroller_updater.yml
@@ -1,15 +1,20 @@
 name: Libcontroller Submodule Updater
 
 on:
-  schedule:
-    - cron:  '0 09 * * *'
-
-env:
-  SUBMODULE_TARGET_BRANCH: R2022b
-  WEBOTS_ROS2_BRANCH: master
+  #schedule:
+  #  - cron:  '0 09 * * *'
+  pull_request:
+    types: [labeled, unlabeled]
 
 jobs:
   automatic-submodule-sync:
+    strategy:
+    matrix:
+      include:
+        - submodule_target_branch: R2022b
+          webots_ros2_branch: master
+        - submodule_target_branch: R2023a
+          webots_ros2_branch: develop
     runs-on: ubuntu-latest
     steps:
       - name: Checkout branch
@@ -17,12 +22,12 @@ jobs:
         with:
           submodules: "true"
           fetch-depth: 0
-          ref: ${{ env.WEBOTS_ROS2_BRANCH }}
+          ref: ${{ matrix.webots_ros2_branch }}
       - name: Update Submodule And Define Unique Branch Name
         run: |
           cd webots_ros2_driver/webots
-          git checkout ${{ env.SUBMODULE_TARGET_BRANCH }} && git pull origin ${{ env.SUBMODULE_TARGET_BRANCH }}
-          echo "BRANCH_NAME=sync-${{ env.WEBOTS_ROS2_BRANCH }}-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+          git checkout ${{ matrix.submodule_target_branch }} && git pull origin ${{ matrix.submodule_target_branch }}
+          echo "BRANCH_NAME=sync-${{ matrix.webots_ros2_branch }}-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
           cd ../..
       - name: Create commit if necessary
         id: create-commit
@@ -46,7 +51,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           source_branch: ${{ env.BRANCH_NAME }}
-          destination_branch: ${{ env.REPO_BRANCH }}
+          destination_branch: ${{ matrix.webots_ros2_branch }}
           pr_title: Sync libcontroller
-          pr_body: Synchronizes libcontroller to the latest commit of branch ${{ env.SUBMODULE_TARGET_BRANCH }}
+          pr_body: Synchronizes libcontroller to the latest commit of branch ${{ env.submodule_target_branch }}
           pr_reviewer: Maintainers

--- a/.github/workflows/libcontroller_updater.yml
+++ b/.github/workflows/libcontroller_updater.yml
@@ -2,7 +2,7 @@ name: Libcontroller Submodule Updater
 
 on:
   schedule:
-    - cron:  '0 11 * * *'
+    - cron:  '0 12 * * *'
 
 jobs:
   automatic-submodule-sync:

--- a/.github/workflows/libcontroller_updater.yml
+++ b/.github/workflows/libcontroller_updater.yml
@@ -2,7 +2,7 @@ name: Libcontroller Submodule Updater
 
 on:
   schedule:
-    - cron:  '0 09 * * *'
+    - cron:  '0 10 * * *'
 
 jobs:
   automatic-submodule-sync:

--- a/.github/workflows/libcontroller_updater.yml
+++ b/.github/workflows/libcontroller_updater.yml
@@ -3,11 +3,12 @@ name: Libcontroller Submodule Updater
 on:
   pull_request:
     types: [labeled, unlabeled]
-  schedule:
-    - cron:  '0 09 * * *'
+  #schedule:
+  #  - cron:  '0 09 * * *'
 
 env:
   SUBMODULE_TARGET_BRANCH: R2022b
+  REPO_BRANCH: master
 
 jobs:
   automatic-submodule-sync:
@@ -18,7 +19,7 @@ jobs:
         with:
           submodules: "true"
           fetch-depth: 0
-          ref: master
+          ref: ${{ env.REPO_BRANCH }}
       - name: Update Submodule And Define Unique Branch Name
         run: |
           cd webots_ros2_driver/webots
@@ -47,7 +48,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           source_branch: ${{ env.BRANCH_NAME }}
-          destination_branch: master
+          destination_branch: ${{ env.REPO_BRANCH }}
           pr_title: Sync libcontroller
           pr_body: Synchronizes libcontroller to the latest commit of branch ${{ env.SUBMODULE_TARGET_BRANCH }}
           pr_reviewer: Maintainers

--- a/.github/workflows/libcontroller_updater.yml
+++ b/.github/workflows/libcontroller_updater.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   SUBMODULE_TARGET_BRANCH: R2022b
-  REPO_BRANCH: master
+  WEBOTS_ROS2_BRANCH: master
 
 jobs:
   automatic-submodule-sync:
@@ -17,12 +17,12 @@ jobs:
         with:
           submodules: "true"
           fetch-depth: 0
-          ref: ${{ env.REPO_BRANCH }}
+          ref: ${{ env.WEBOTS_ROS2_BRANCH }}
       - name: Update Submodule And Define Unique Branch Name
         run: |
           cd webots_ros2_driver/webots
           git checkout ${{ env.SUBMODULE_TARGET_BRANCH }} && git pull origin ${{ env.SUBMODULE_TARGET_BRANCH }}
-          echo "BRANCH_NAME=sync-develop-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+          echo "BRANCH_NAME=sync-${{ env.WEBOTS_ROS2_BRANCH }}-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
           cd ../..
       - name: Create commit if necessary
         id: create-commit

--- a/.github/workflows/libcontroller_updater.yml
+++ b/.github/workflows/libcontroller_updater.yml
@@ -2,7 +2,7 @@ name: Libcontroller Submodule Updater
 
 on:
   schedule:
-    - cron:  '0 10 * * *'
+    - cron:  '0 11 * * *'
 
 jobs:
   automatic-submodule-sync:

--- a/.github/workflows/libcontroller_updater.yml
+++ b/.github/workflows/libcontroller_updater.yml
@@ -9,12 +9,12 @@ on:
 jobs:
   automatic-submodule-sync:
     strategy:
-    matrix:
-      include:
-        - submodule_target_branch: R2022b
-          webots_ros2_branch: master
-        - submodule_target_branch: R2023a
-          webots_ros2_branch: develop
+      matrix:
+        include:
+          - submodule_target_branch: R2022b
+            webots_ros2_branch: master
+          - submodule_target_branch: R2023a
+            webots_ros2_branch: develop
     runs-on: ubuntu-latest
     steps:
       - name: Checkout branch

--- a/.github/workflows/libcontroller_updater.yml
+++ b/.github/workflows/libcontroller_updater.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - submodule_target_branch: R2022b
+          - submodule_target_branch: R2022b-revision-1
             webots_ros2_branch: master
           - submodule_target_branch: R2023a
             webots_ros2_branch: develop

--- a/.github/workflows/libcontroller_updater.yml
+++ b/.github/workflows/libcontroller_updater.yml
@@ -1,10 +1,8 @@
 name: Libcontroller Submodule Updater
 
 on:
-  #schedule:
-  #  - cron:  '0 09 * * *'
-  pull_request:
-    types: [labeled, unlabeled]
+  schedule:
+    - cron:  '0 09 * * *'
 
 jobs:
   automatic-submodule-sync:
@@ -52,6 +50,6 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           source_branch: ${{ env.BRANCH_NAME }}
           destination_branch: ${{ matrix.webots_ros2_branch }}
-          pr_title: Sync libcontroller
-          pr_body: Synchronizes libcontroller to the latest commit of branch ${{ env.submodule_target_branch }}
+          pr_title: Sync libcontroller ${{ matrix.submodule_target_branch }}
+          pr_body: Synchronizes libcontroller to the latest commit of branch ${{ matrix.submodule_target_branch }}.
           pr_reviewer: Maintainers

--- a/.github/workflows/libcontroller_updater.yml
+++ b/.github/workflows/libcontroller_updater.yml
@@ -1,10 +1,8 @@
 name: Libcontroller Submodule Updater
 
 on:
-  pull_request:
-    types: [labeled, unlabeled]
-  #schedule:
-  #  - cron:  '0 09 * * *'
+  schedule:
+    - cron:  '0 09 * * *'
 
 env:
   SUBMODULE_TARGET_BRANCH: R2022b
@@ -39,7 +37,7 @@ jobs:
             git push origin ${{ env.BRANCH_NAME }}
             echo "create_pull_request=1" >> $GITHUB_OUTPUT
           else
-            echo "Submodule is up to date";
+            echo "Submodule is already up to date.";
             echo "create_pull_request=0" >> $GITHUB_OUTPUT
           fi
       - name: Create Pull Request

--- a/.github/workflows/libcontroller_updater.yml
+++ b/.github/workflows/libcontroller_updater.yml
@@ -2,7 +2,7 @@ name: Libcontroller Submodule Updater
 
 on:
   schedule:
-    - cron:  '0 12 * * *'
+    - cron:  '0 13 * * *'
 
 jobs:
   automatic-submodule-sync:

--- a/.github/workflows/libcontroller_updater.yml
+++ b/.github/workflows/libcontroller_updater.yml
@@ -1,0 +1,53 @@
+name: Libcontroller Submodule Updater
+
+on:
+  pull_request:
+    types: [labeled, unlabeled]
+  schedule:
+    - cron:  '0 09 * * *'
+
+env:
+  SUBMODULE_TARGET_BRANCH: R2022b
+
+jobs:
+  automatic-submodule-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v3
+        with:
+          submodules: "true"
+          fetch-depth: 0
+          ref: master
+      - name: Update Submodule And Define Unique Branch Name
+        run: |
+          cd webots_ros2_driver/webots
+          git checkout ${{ env.SUBMODULE_TARGET_BRANCH }} && git pull origin ${{ env.SUBMODULE_TARGET_BRANCH }}
+          echo "BRANCH_NAME=sync-develop-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+          cd ../..
+      - name: Create commit if necessary
+        id: create-commit
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "Submodule needs sync!";
+            git config --global user.name ${GITHUB_ACTOR}
+            git config --global user.email ${GITHUB_ACTOR}@github.com
+            git checkout -b ${{ env.BRANCH_NAME }}
+            git add .
+            git commit -m "Sync submodule"
+            git push origin ${{ env.BRANCH_NAME }}
+            echo "create_pull_request=1" >> $GITHUB_OUTPUT
+          else
+            echo "Submodule is up to date";
+            echo "create_pull_request=0" >> $GITHUB_OUTPUT
+          fi
+      - name: Create Pull Request
+        if: ${{ steps.create-commit.outputs.create_pull_request == 1 }}
+        uses: repo-sync/pull-request@v2.6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          source_branch: ${{ env.BRANCH_NAME }}
+          destination_branch: master
+          pr_title: Sync libcontroller
+          pr_body: Synchronizes libcontroller to the latest commit of branch ${{ env.SUBMODULE_TARGET_BRANCH }}
+          pr_reviewer: Maintainers


### PR DESCRIPTION
**Description**

Proof of concept for automatic creation of PRs when a sync of libcontroller is necessary.
It's also possible to have a workflow (in libcontroller repo) that triggers when something gets merged such that it dispatches an event to this repo, triggering a workflow here which opens the PR. For our purpose however that would be overkill as the libcontroller repo gets updated at most once per day (when the nightlies are created), if even that. It's sufficient to check daily.