### PR TITLE
Fix relative PROTO not being found

### DIFF
--- a/webots_ros2_driver/webots_ros2_driver/webots_launcher.py
+++ b/webots_ros2_driver/webots_ros2_driver/webots_launcher.py
@@ -106,11 +106,11 @@ class WebotsLauncher(ExecuteProcess):
         with open(self.__world_copy.name, 'r') as file:
             content = file.read()
 
-        for match in re.finditer('url\s*\[?\s*\"(.*?)\"', content):
+        for match in re.finditer('\"((?:[^\"]*)\\.(?:jpe?g|png|hdr|obj|stl|dae|wav|mp3|proto))\"', content):
             url_path = match.group(1)
 
             # Absolute path or Webots relative path or Web paths
-            if os.path.isabs(url_path) or 'webots://' in url_path or 'http://' in url_path or 'https://' in url_path:
+            if os.path.isabs(url_path) or url_path.startswith('webots://') or url_path.startswith('http://') or url_path.startswith('https://'):
                 continue
 
             new_url_path = '"' + os.path.split(world_path)[0] + '/' + url_path + '"'


### PR DESCRIPTION
**Description**

As reported by a user, relative PROTO were not being found. Due to the introduction of ROS2Supervisor, the world file needs to be edited prior to launching it in order to append the VRML of the ROS2Supervisor node. The edited copy is launched from /tmp, and relative urls of assets are adjusted accordingly. The replacement logic however is more strict than it needs to (requiring `url something`) and didn't apply to PROTO.