### PR TITLE
Adjust nightly timings and concurrency

### DIFF
--- a/.github/workflows/libcontroller_updater.yml
+++ b/.github/workflows/libcontroller_updater.yml
@@ -2,7 +2,7 @@ name: Libcontroller Submodule Updater
 
 on:
   schedule:
-    - cron:  '0 06 * * *'
+    - cron:  '0 05 * * *'
 
 jobs:
   automatic-submodule-sync:

--- a/.github/workflows/libcontroller_updater.yml
+++ b/.github/workflows/libcontroller_updater.yml
@@ -2,7 +2,7 @@ name: Libcontroller Submodule Updater
 
 on:
   schedule:
-    - cron:  '0 05 * * *'
+    - cron:  '0 04 * * *'
 
 jobs:
   automatic-submodule-sync:

--- a/.github/workflows/libcontroller_updater.yml
+++ b/.github/workflows/libcontroller_updater.yml
@@ -2,7 +2,7 @@ name: Libcontroller Submodule Updater
 
 on:
   schedule:
-    - cron:  '0 13 * * *'
+    - cron:  '0 06 * * *'
 
 jobs:
   automatic-submodule-sync:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,10 @@ on:
   schedule:
     - cron:  '0 02 * * *'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   industrial_ci:
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
   schedule:
-    - cron:  '0 23 * * *'
+    - cron:  '0 03 * * *'
 
 jobs:
   industrial_ci:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
   schedule:
-    - cron:  '0 03 * * *'
+    - cron:  '0 02 * * *'
 
 jobs:
   industrial_ci:

--- a/.github/workflows/test_develop.yml
+++ b/.github/workflows/test_develop.yml
@@ -2,7 +2,7 @@ name: ROS2 tests (develop)
 
 on:
   schedule:
-    - cron:  '0 03 * * *'
+    - cron:  '0 02 * * *'
 
 jobs:
   industrial_ci:

--- a/.github/workflows/test_develop.yml
+++ b/.github/workflows/test_develop.yml
@@ -4,6 +4,10 @@ on:
   schedule:
     - cron:  '0 02 * * *'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   industrial_ci:
     strategy:

--- a/.github/workflows/test_develop.yml
+++ b/.github/workflows/test_develop.yml
@@ -2,7 +2,7 @@ name: ROS2 tests (develop)
 
 on:
   schedule:
-    - cron:  '0 23 * * *'
+    - cron:  '0 03 * * *'
 
 jobs:
   industrial_ci:


### PR DESCRIPTION
**Description**

The libcontroller sync appears to have worked as intended.

This PR:
- Change the time when nighty tests are run (currently the time set is fairly overlapping with the time when the deb itself is generated, so might lead to odd runs if there are delays/slow machines)
- Change the time the sync check is done (early morning, so we have the full day to do something about it if something breaks)
- Make so that workflows currently being run are canceled if a new push occurs (currently it keeps running and a new run is launched for every commit)