### PR TITLE
Update link to wiki page in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It integrates with ROS2 using ROS2 messages, services and actions.
 
 Please visit the [documentation](https://github.com/cyberbotics/webots_ros2/wiki) that contains the following sections:
 - [Getting Started](https://github.com/cyberbotics/webots_ros2/wiki/Getting-Started)
-- [Build and Install](https://github.com/cyberbotics/webots_ros2/wiki/Complete-Installation-Guide)
+- [Complete Installation Guide](https://github.com/cyberbotics/webots_ros2/wiki/Complete-Installation-Guide)
 - [Tutorials](https://github.com/cyberbotics/webots_ros2/wiki/Tutorials)
 - [Examples](https://github.com/cyberbotics/webots_ros2/wiki/Examples)
 - [References](https://github.com/cyberbotics/webots_ros2/wiki/References)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It integrates with ROS2 using ROS2 messages, services and actions.
 
 Please visit the [documentation](https://github.com/cyberbotics/webots_ros2/wiki) that contains the following sections:
 - [Getting Started](https://github.com/cyberbotics/webots_ros2/wiki/Getting-Started)
-- [Build and Install](https://github.com/cyberbotics/webots_ros2/wiki/Build-and-Install)
+- [Build and Install](https://github.com/cyberbotics/webots_ros2/wiki/Complete-Installation-Guide)
 - [Tutorials](https://github.com/cyberbotics/webots_ros2/wiki/Tutorials)
 - [Examples](https://github.com/cyberbotics/webots_ros2/wiki/Examples)
 - [References](https://github.com/cyberbotics/webots_ros2/wiki/References)


### PR DESCRIPTION
The link to the `Build and Install` wiki page is no longer working.
Not sure if the new documentation page is still a work in progress.