### PR TITLE
Update calculation of `CameraRecognitionObject`

### DIFF
--- a/webots_ros2/CHANGELOG.rst
+++ b/webots_ros2/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package webots_ros2
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2022.1.5 (2022-11-17)
+------------------
+* Update the calculation of CameraRecognitionObject messages to the RDF convention of R2022b.
+
 2022.1.4 (2022-XX-XX)
 ------------------
 * Fix the camera focal length in the CameraInfo topic.

--- a/webots_ros2_driver/CHANGELOG.rst
+++ b/webots_ros2_driver/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package webots_ros2_driver
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2022.1.5 (2022-11-17)
+------------------
+* Update the calculation of CameraRecognitionObject messages to the RDF convention of R2022b.
+
 2022.1.4 (2022-XX-XX)
 ------------------
 * Fix the camera focal length in the CameraInfo topic.

--- a/webots_ros2_driver/CMakeLists.txt
+++ b/webots_ros2_driver/CMakeLists.txt
@@ -32,6 +32,7 @@ find_package(rclcpp REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
+find_package(tf2_geometry_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(vision_msgs REQUIRED)
 find_package(webots_ros2_msgs REQUIRED)
@@ -137,6 +138,7 @@ ament_target_dependencies(driver
   pluginlib
   sensor_msgs
   std_msgs
+  tf2_geometry_msgs
   tf2_ros
   vision_msgs
   webots_ros2_msgs
@@ -258,6 +260,7 @@ ament_export_dependencies(
   rclpy
   sensor_msgs
   std_msgs
+  tf2_geometry_msgs
   tf2_ros
   vision_msgs
   webots_ros2_msgs

--- a/webots_ros2_driver/include/webots_ros2_driver/plugins/static/Ros2Camera.hpp
+++ b/webots_ros2_driver/include/webots_ros2_driver/plugins/static/Ros2Camera.hpp
@@ -21,6 +21,8 @@
 
 #include <geometry_msgs/msg/quaternion.hpp>
 #include <geometry_msgs/msg/point.hpp>
+#include <geometry_msgs/msg/transform_stamped.hpp>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include <sensor_msgs/image_encodings.hpp>
 #include <sensor_msgs/msg/camera_info.hpp>
 #include <sensor_msgs/msg/image.hpp>

--- a/webots_ros2_driver/package.xml
+++ b/webots_ros2_driver/package.xml
@@ -21,6 +21,7 @@
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
   <depend>geometry_msgs</depend>
+  <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>vision_msgs</depend>
   <depend>tinyxml2_vendor</depend>

--- a/webots_ros2_driver/src/plugins/static/Ros2Camera.cpp
+++ b/webots_ros2_driver/src/plugins/static/Ros2Camera.cpp
@@ -136,18 +136,25 @@ namespace webots_ros2_driver
     for (size_t i = 0; i < mCamera->getRecognitionNumberOfObjects(); i++)
     {
       // Getting Object Info
-      geometry_msgs::msg::Point position;
-      geometry_msgs::msg::Quaternion orientation;
-      position.x = objects[i].position[0];
-      position.y = objects[i].position[1];
-      position.z = objects[i].position[2];
-      axisAngleToQuaternion(objects[i].orientation, orientation);
+      geometry_msgs::msg::PoseStamped pose;
+      pose.pose.position.x = objects[i].position[0];
+      pose.pose.position.y = objects[i].position[1];
+      pose.pose.position.z = objects[i].position[2];
+      axisAngleToQuaternion(objects[i].orientation, pose.pose.orientation);
+
+      // Transform to ROS camera coordinate frame
+      // rpy = (0, pi/2, -pi/2)
+      geometry_msgs::msg::TransformStamped transform;
+      transform.transform.rotation.x = 0.5;
+      transform.transform.rotation.y = -0.5;
+      transform.transform.rotation.z = 0.5;
+      transform.transform.rotation.w = 0.5;
+      tf2::doTransform(pose, pose, transform);
 
       // Object Info -> Detection2D
       vision_msgs::msg::Detection2D detection;
       vision_msgs::msg::ObjectHypothesisWithPose hypothesis;
-      hypothesis.pose.pose.position = position;
-      hypothesis.pose.pose.orientation = orientation;
+      hypothesis.pose.pose = pose.pose;
       detection.results.push_back(hypothesis);
       #if FOXY || GALACTIC
       detection.bbox.center.x = objects[i].position_on_image[0];
@@ -164,8 +171,7 @@ namespace webots_ros2_driver
       webots_ros2_msgs::msg::CameraRecognitionObject recognitionWebotsObject;
       recognitionWebotsObject.id = objects[i].id;
       recognitionWebotsObject.model = std::string(objects[i].model);
-      recognitionWebotsObject.pose.pose.position = position;
-      recognitionWebotsObject.pose.pose.orientation = orientation;
+      recognitionWebotsObject.pose = pose;
       #if FOXY || GALACTIC
       recognitionWebotsObject.bbox.center.x = objects[i].position_on_image[0];
       recognitionWebotsObject.bbox.center.y = objects[i].position_on_image[1];

--- a/webots_ros2_tests/CHANGELOG.rst
+++ b/webots_ros2_tests/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package webots_ros2_tests
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+1.2.2 (2022-11-17)
+------------------
+* Add a system test for the R2022b RDF convention for cameras.
+
 1.2.1 (2022-01-10)
 ------------------
 * Add a system test for the FLU lidar device.

--- a/webots_ros2_tests/test/test_system_driver.py
+++ b/webots_ros2_tests/test/test_system_driver.py
@@ -28,6 +28,7 @@ from std_srvs.srv import Trigger
 from sensor_msgs.msg import Range, Image, Imu, Illuminance
 from std_msgs.msg import Int32, Float32
 from geometry_msgs.msg import PointStamped, Vector3
+from webots_ros2_msgs.msg import CameraRecognitionObjects
 from launch import LaunchDescription
 from launch_ros.actions import Node
 import launch
@@ -123,6 +124,15 @@ class TestDriver(TestWebots):
             return True
 
         self.wait_for_messages(self.__node, Image, '/Pioneer_3_AT/kinect_color', condition=on_image_received)
+
+    def testRecognition(self):
+        def on_objects_received(message):
+            self.assertAlmostEqual(message.objects[0].pose.pose.position.x, 0.08, delta=0.01)
+            self.assertAlmostEqual(message.objects[0].pose.pose.position.y, -0.09, delta=0.01)
+            self.assertAlmostEqual(message.objects[0].pose.pose.position.z, 0.55, delta=0.01)
+            return True
+
+        self.wait_for_messages(self.__node, CameraRecognitionObjects, '/Pioneer_3_AT/camera/recognitions/webots', condition=on_objects_received)
 
     def testPythonPluginService(self):
         client = self.__node.create_client(Trigger, 'move_forward')

--- a/webots_ros2_tests/test/test_system_driver.py
+++ b/webots_ros2_tests/test/test_system_driver.py
@@ -132,7 +132,8 @@ class TestDriver(TestWebots):
             self.assertAlmostEqual(message.objects[0].pose.pose.position.z, 0.55, delta=0.01)
             return True
 
-        self.wait_for_messages(self.__node, CameraRecognitionObjects, '/Pioneer_3_AT/camera/recognitions/webots', condition=on_objects_received)
+        self.wait_for_messages(self.__node, CameraRecognitionObjects, '/Pioneer_3_AT/camera/recognitions/webots',
+                               condition=on_objects_received)
 
     def testPythonPluginService(self):
         client = self.__node.create_client(Trigger, 'move_forward')

--- a/webots_ros2_tests/worlds/.driver_test.wbproj
+++ b/webots_ros2_tests/worlds/.driver_test.wbproj
@@ -9,3 +9,4 @@ textFiles: -1
 consoles: Console:All:All
 renderingDevicePerspectives: Pioneer 3-AT:kinect color;1;1;0;0
 renderingDevicePerspectives: Pioneer 3-AT:kinect range;1;1;0;0
+renderingDevicePerspectives: Pioneer 3-AT:camera;0;1;0;0

--- a/webots_ros2_tests/worlds/driver_test.wbt
+++ b/webots_ros2_tests/worlds/driver_test.wbt
@@ -8,6 +8,7 @@ EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2022b/project
 EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2022b/projects/devices/robotis/protos/RobotisLds01.proto"
 EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2022b/projects/devices/microsoft/protos/Kinect.proto"
 EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2022b/projects/appearances/protos/Plaster.proto"
+EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2022b/projects/appearances/protos/RedBricks.proto"
 
 WorldInfo {
 }
@@ -24,6 +25,21 @@ Floor {
 CardboardBox {
   translation 1.21847 0.00917563 0.3
   rotation 0.7040631892342535 -0.09269012491274485 -0.7040621892339847 -2.9567353071795863
+}
+Solid {
+  translation -0.5 0.08 0.34
+  children [
+    Shape {
+      appearance RedBricks {
+      }
+      geometry Box {
+        size 0.1 0.1 0.1
+      }
+    }
+  ]
+  recognitionColors [
+    1 0 0
+  ]
 }
 Pioneer3at {
   name "Pioneer_3_AT"
@@ -64,6 +80,12 @@ Pioneer3at {
       ]
       boundingObject USE ROD_SHAPE
       physics Physics {
+      }
+    }
+    Camera {
+      translation -0.25 0 0.25
+      rotation 0 0 1 3.14159
+      recognition Recognition {
       }
     }
   ]


### PR DESCRIPTION
Calculation now conforms to the new camera coordinate frame introduced with Webots R2022b.

Signed-off-by: Andreas Kreutz <andreas.kreutz@hotmail.de>

**Description**
With the release of Webots R2022b, the coordinate frame for cameras has been changed. This means that the calculation of `CameraRecognitionObject` messages needs to be updated. 

**Related Issues**
This pull-request fixes issue #517 

**Affected Packages**
List of affected packages:
  - webots_ros2_driver
  - webots_ros2_tests
