### PR TITLE
cmake symlinks

### DIFF
--- a/webots_ros2_driver/CMakeLists.txt
+++ b/webots_ros2_driver/CMakeLists.txt
@@ -181,7 +181,7 @@ install(
 
 # Create symlinks of libController
 macro(lib_symlink filename)
-  install(CODE "execute_process(COMMAND ln -sf ${CMAKE_INSTALL_PREFIX}/lib/controller/${filename} ${CMAKE_INSTALL_PREFIX}/lib/${filename})")
+  install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_INSTALL_PREFIX}/lib/controller/${filename} ${CMAKE_INSTALL_PREFIX}/lib/${filename})")
 endmacro(lib_symlink)
 
 lib_symlink(libController.so)


### PR DESCRIPTION
Attempts to fix #567.

Symlinks to the libController binaries were not created in the buildfarm because of permissions, leading to a broken released package. 

This PR attempts to create the symlinks with the cmake command instead of `ln -sf`.