### PR TITLE
WSL error: local PROTOs cannot be loaded

### DIFF
--- a/webots_ros2/CHANGELOG.rst
+++ b/webots_ros2/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package webots_ros2
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2023.0.1 (2023-XX-XX)
+------------------
+* Fix relative assets in WSL.
+
 2023.0.0 (2022-11-30)
 ------------------
 * Add support for the new Python API of Webots R2023a

--- a/webots_ros2_driver/CHANGELOG.rst
+++ b/webots_ros2_driver/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package webots_ros2_driver
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2023.0.1 (2023-XX-XX)
+------------------
+* Fix relative assets in WSL.
+
 2023.0.0 (2022-11-30)
 ------------------
 * Add support for the new Python API of Webots R2023a

--- a/webots_ros2_driver/webots_ros2_driver/webots_launcher.py
+++ b/webots_ros2_driver/webots_ros2_driver/webots_launcher.py
@@ -157,7 +157,10 @@ class WebotsLauncher(ExecuteProcess):
             if os.path.isabs(url_path) or url_path.startswith('webots://') or url_path.startswith('http://') or url_path.startswith('https://'):
                 continue
 
-            new_url_path = '"' + os.path.split(world_path)[0] + '/' + url_path + '"'
+            new_url_path = os.path.split(world_path)[0] + '/' + url_path
+            if self.__is_wsl:
+                new_url_path = subprocess.check_output(['wslpath', '-w', new_url_path]).strip().decode('utf-8').replace('\\', '/')
+            new_url_path = '"' + new_url_path + '"'
             url_path = '"' + url_path + '"'
             content = content.replace(url_path, new_url_path)
 


### PR DESCRIPTION
On WSL, worlds referring to local protos could not be loaded because the path is not correctly modified in the world file.