### PR TITLE
Fix rats life example launcher

### DIFF
--- a/webots_ros2/CHANGELOG.rst
+++ b/webots_ros2/CHANGELOG.rst
@@ -4,11 +4,12 @@ Changelog for package webots_ros2
 
 2023.0.1 (2023-XX-XX)
 ------------------
-* Fix relative assets in WSL.
+* Fixed relative assets in WSL.
+* Fixed broken controller connection in Rats life example.
 
 2023.0.0 (2022-11-30)
 ------------------
-* Add support for the new Python API of Webots R2023a
+* Added support for the new Python API of Webots R2023a
 * Convert C++ controller API functions to C
 * Replace libController submodule by commited source files
 * Removed 'webots_ros2_core' package (deprecated).
@@ -16,7 +17,7 @@ Changelog for package webots_ros2
 
 2022.1.4 (2022-11-18)
 ------------------
-* Fix the camera focal length in the CameraInfo topic.
+* Fixed the camera focal length in the CameraInfo topic.
 * Upgraded to urdf2webots 2.0.3
 * Update the calculation of CameraRecognitionObject messages to the RDF convention of R2022b.
 

--- a/webots_ros2_epuck/CHANGELOG.rst
+++ b/webots_ros2_epuck/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package webots_ros2_epuck
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2023.0.1 (2023-XX-XX)
+------------------
+* Fixed broken controller connection in Rats life example.
+
 2022.1.3 (2022-11-02)
 ------------------
 * Added macOS support.

--- a/webots_ros2_epuck/worlds/rats_life_benchmark.wbt
+++ b/webots_ros2_epuck/worlds/rats_life_benchmark.wbt
@@ -318,6 +318,7 @@ Floor {
 E-puck {
   translation 0 -0.05 0.0066
   rotation 0 0 1 3.14159
+  name "epuck"
   controller "<extern>"
   version "2"
   camera_width 640


### PR DESCRIPTION
The name of the epuck in the rats life example is not consistent with the one in the basic epuck example. The robot_launch.py script is failing for the rats life example