### PR TITLE
Revert E-puck name to `e-puck`

### DIFF
--- a/webots_ros2_epuck/launch/robot_launch.py
+++ b/webots_ros2_epuck/launch/robot_launch.py
@@ -69,7 +69,7 @@ def get_ros2_nodes(*args):
         package='webots_ros2_driver',
         executable='driver',
         output='screen',
-        additional_env={'WEBOTS_CONTROLLER_URL': controller_url_prefix() + 'epuck'},
+        additional_env={'WEBOTS_CONTROLLER_URL': controller_url_prefix() + 'e-puck'},
         parameters=[
             {'robot_description': robot_description,
              'use_sim_time': use_sim_time,

--- a/webots_ros2_epuck/worlds/epuck_world.wbt
+++ b/webots_ros2_epuck/worlds/epuck_world.wbt
@@ -52,7 +52,6 @@ WoodenBox {
 E-puck {
   translation 0.0530459 0.00806403 0.001
   rotation 0 0 1 3.1415
-  name "e-puck"
   controller "<extern>"
   version "2"
   camera_width 640

--- a/webots_ros2_epuck/worlds/epuck_world.wbt
+++ b/webots_ros2_epuck/worlds/epuck_world.wbt
@@ -52,7 +52,7 @@ WoodenBox {
 E-puck {
   translation 0.0530459 0.00806403 0.001
   rotation 0 0 1 3.1415
-  name "epuck"
+  name "e-puck"
   controller "<extern>"
   version "2"
   camera_width 640

--- a/webots_ros2_epuck/worlds/rats_life_benchmark.wbt
+++ b/webots_ros2_epuck/worlds/rats_life_benchmark.wbt
@@ -318,7 +318,6 @@ Floor {
 E-puck {
   translation 0 -0.05 0.0066
   rotation 0 0 1 3.14159
-  name "e-puck"
   controller "<extern>"
   version "2"
   camera_width 640

--- a/webots_ros2_epuck/worlds/rats_life_benchmark.wbt
+++ b/webots_ros2_epuck/worlds/rats_life_benchmark.wbt
@@ -318,7 +318,7 @@ Floor {
 E-puck {
   translation 0 -0.05 0.0066
   rotation 0 0 1 3.14159
-  name "epuck"
+  name "e-puck"
   controller "<extern>"
   version "2"
   camera_width 640


### PR DESCRIPTION
#574 fixed the name from `e-puck` to `epuck` in the rats life example.

To be consistent with the default name of the E-puck, this PR reverts the change and modifies the name from `epuck` to `e-puck` in the launcher and the epuck_world instead.