### PR TITLE
Fix URDF spawner on macOS and WSL

### DIFF
--- a/webots_ros2/CHANGELOG.rst
+++ b/webots_ros2/CHANGELOG.rst
@@ -2,15 +2,12 @@
 Changelog for package webots_ros2
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-2023.0.3 (2023-XX-XX)
-------------------
-* Ros2Supervisor is now optional.
-
 2023.0.2 (2023-XX-XX)
 ------------------
 * Drop support for Galactic.
 * Fixed the spawn of URDF robots in WSL and macOS when using full path.
 * Fixed relative assets in macOS.
+* Ros2Supervisor is now optional.
 
 2023.0.1 (2023-01-05)
 ------------------

--- a/webots_ros2/CHANGELOG.rst
+++ b/webots_ros2/CHANGELOG.rst
@@ -8,7 +8,6 @@ Changelog for package webots_ros2
 * Fixed the spawn of URDF robots in WSL and macOS when using full path.
 * Fixed relative assets in macOS.
 
-
 2023.0.1 (2023-01-05)
 ------------------
 * Fixed relative assets in WSL.

--- a/webots_ros2/CHANGELOG.rst
+++ b/webots_ros2/CHANGELOG.rst
@@ -5,6 +5,7 @@ Changelog for package webots_ros2
 2023.0.2 (2023-XX-XX)
 ------------------
 * Drop support for Galactic.
+* Fixed the spawn of URDF robots in WSL and macOS when using full path.
 
 2023.0.1 (2023-01-05)
 ------------------

--- a/webots_ros2_driver/CHANGELOG.rst
+++ b/webots_ros2_driver/CHANGELOG.rst
@@ -2,14 +2,11 @@
 Changelog for package webots_ros2_driver
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-2023.0.3 (2023-XX-XX)
-------------------
-* Added Ros2Supervisor creation.
-
 2023.0.2 (2023-XX-XX)
 ------------------
 * Fixed the spawn of URDF robots in WSL and macOS when using full path.
 * Fixed relative assets in macOS.
+* Added Ros2Supervisor creation.
 
 2023.0.1 (2023-01-05)
 ------------------

--- a/webots_ros2_driver/CHANGELOG.rst
+++ b/webots_ros2_driver/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package webots_ros2_driver
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2023.0.2 (2023-XX-XX)
+------------------
+* Fixed the spawn of URDF robots in WSL and macOS when using full path.
+
 2023.0.1 (2023-01-05)
 ------------------
 * Fix relative assets in WSL.

--- a/webots_ros2_driver/webots_ros2_driver/ros2_supervisor.py
+++ b/webots_ros2_driver/webots_ros2_driver/ros2_supervisor.py
@@ -102,8 +102,8 @@ class Ros2Supervisor(Node):
                 # Read the content of the URDF
                 with open(robot.urdf_path, 'r') as file:
                     urdfContent = file.read()
-                if urdfContent is None:
-                    sys.exit('Could not read the URDF file.')
+                    if urdfContent is None:
+                        sys.exit('Could not read the URDF file.')
 
                 # Get the package name and parent resource directory from URDF path
                 split_path = robot.urdf_path.split(os.path.sep)

--- a/webots_ros2_driver/webots_ros2_driver/ros2_supervisor.py
+++ b/webots_ros2_driver/webots_ros2_driver/ros2_supervisor.py
@@ -121,7 +121,8 @@ class Ros2Supervisor(Node):
                         os.mkdir(shared_package_dir)
                     if (not os.path.isdir(shared_resource_dir)):
                         shutil.copytree(resource_dir, shared_resource_dir)
-                    relative_path_prefix = os.path.join(host_shared_folder(), os.path.basename(package_dir), os.path.basename(resource_dir))
+                    relative_path_prefix = os.path.join(host_shared_folder(), os.path.basename(package_dir),
+                                                        os.path.basename(resource_dir))
                 # In WSL, the prefix must be converted to WSL path to work in Webots running on native Windows
                 if is_wsl():
                     relative_path_prefix = resource_dir
@@ -129,9 +130,9 @@ class Ros2Supervisor(Node):
                     relative_path_prefix = subprocess.check_output(command).strip().decode('utf-8').replace('\\', '/')
 
                 robot_string = convertUrdfContent(input=urdfContent, robotName=robot_name, normal=normal,
-                                              boxCollision=box_collision, initTranslation=robot_translation,
-                                              initRotation=robot_rotation, initPos=init_pos,
-                                              relativePathPrefix=relative_path_prefix)
+                                                  boxCollision=box_collision, initTranslation=robot_translation,
+                                                  initRotation=robot_rotation, initPos=init_pos,
+                                                  relativePathPrefix=relative_path_prefix)
             else:
                 robot_string = convertUrdfFile(input=robot.urdf_path, robotName=robot_name, normal=normal,
                                                boxCollision=box_collision, initTranslation=robot_translation,
@@ -158,7 +159,8 @@ class Ros2Supervisor(Node):
                     os.mkdir(shared_package_dir)
                 if (not os.path.isdir(shared_resource_dir)):
                     shutil.copytree(resource_dir, shared_resource_dir)
-                relative_path_prefix = os.path.join(host_shared_folder(), os.path.basename(package_dir), os.path.basename(resource_dir))
+                relative_path_prefix = os.path.join(host_shared_folder(), os.path.basename(package_dir),
+                                                    os.path.basename(resource_dir))
             robot_string = convertUrdfContent(input=robot.robot_description, robotName=robot_name, normal=normal,
                                               boxCollision=box_collision, initTranslation=robot_translation,
                                               initRotation=robot_rotation, initPos=init_pos,

--- a/webots_ros2_driver/webots_ros2_driver/ros2_supervisor.py
+++ b/webots_ros2_driver/webots_ros2_driver/ros2_supervisor.py
@@ -109,11 +109,17 @@ class Ros2Supervisor(Node):
                 components = robot.urdf_path.split(os.path.sep)
                 for i, component in enumerate(reversed(components)):
                     if component == 'share':
+                        package_dir = os.path.sep.join(components[:-i + 1])
                         resource_dir = os.path.sep.join(components[:-i + 2])
                         break
-                if (not os.path.isdir(os.path.join(container_shared_folder(), os.path.basename(resource_dir)))):
-                    shutil.copytree(resource_dir, os.path.join(container_shared_folder(), os.path.basename(resource_dir)))
-                relative_path_prefix = os.path.dirname(robot.urdf_path)
+                shared_package_dir = os.path.join(container_shared_folder(), os.path.basename(package_dir))
+                shared_resource_dir = os.path.join(shared_package_dir, os.path.basename(resource_dir))
+                if (not os.path.isdir(shared_package_dir)):
+                    os.mkdir(shared_package_dir)
+                if (not os.path.isdir(shared_resource_dir)):
+                    shutil.copytree(resource_dir, shared_resource_dir)
+                relative_path_prefix = os.path.join(host_shared_folder(), os.path.basename(package_dir), os.path.basename(resource_dir))
+                self.get_logger().info(relative_path_prefix)
 
                 robot_string = convertUrdfContent(input=urdfContent, robotName=robot_name, normal=normal,
                                               boxCollision=box_collision, initTranslation=robot_translation,
@@ -129,10 +135,19 @@ class Ros2Supervisor(Node):
                 command = ['wslpath', '-w', relative_path_prefix]
                 relative_path_prefix = subprocess.check_output(command).strip().decode('utf-8').replace('\\', '/')
             if has_shared_folder() and relative_path_prefix:
-                if not os.path.isdir(os.path.join(container_shared_folder(), os.path.basename(relative_path_prefix))):
-                    shutil.copytree(relative_path_prefix, os.path.join(container_shared_folder(),
-                                    os.path.basename(relative_path_prefix)))
-                relative_path_prefix = os.path.join(host_shared_folder(), os.path.basename(relative_path_prefix))              
+                components = relative_path_prefix.split(os.path.sep)
+                for i, component in enumerate(reversed(components)):
+                    if component == 'share':
+                        package_dir = os.path.sep.join(components[:-i + 1])
+                        resource_dir = os.path.sep.join(components[:-i + 2])
+                        break
+                shared_package_dir = os.path.join(container_shared_folder(), os.path.basename(package_dir))
+                shared_resource_dir = os.path.join(shared_package_dir, os.path.basename(resource_dir))
+                if (not os.path.isdir(shared_package_dir)):
+                    os.mkdir(shared_package_dir)
+                if (not os.path.isdir(shared_resource_dir)):
+                    shutil.copytree(resource_dir, shared_resource_dir)
+                relative_path_prefix = os.path.join(host_shared_folder(), os.path.basename(package_dir), os.path.basename(resource_dir))              
             robot_string = convertUrdfContent(input=robot.robot_description, robotName=robot_name, normal=normal,
                                               boxCollision=box_collision, initTranslation=robot_translation,
                                               initRotation=robot_rotation, initPos=init_pos,

--- a/webots_ros2_driver/webots_ros2_driver/ros2_supervisor.py
+++ b/webots_ros2_driver/webots_ros2_driver/ros2_supervisor.py
@@ -106,11 +106,11 @@ class Ros2Supervisor(Node):
                 if urdfContent is None:
                     sys.exit('Could not read the URDF file.')
 
-                components = robot.urdf_path.split(os.path.sep)
-                for i, component in enumerate(reversed(components)):
-                    if component == 'share':
-                        package_dir = os.path.sep.join(components[:-i + 1])
-                        resource_dir = os.path.sep.join(components[:-i + 2])
+                split_path = robot.urdf_path.split(os.path.sep)
+                for i, folder in (list(enumerate(split_path))):
+                    if folder == "share":
+                        package_dir = os.path.sep.join(split_path[:i + 2])
+                        resource_dir = os.path.sep.join(split_path[:i + 3])
                         break
                 shared_package_dir = os.path.join(container_shared_folder(), os.path.basename(package_dir))
                 shared_resource_dir = os.path.join(shared_package_dir, os.path.basename(resource_dir))
@@ -135,11 +135,11 @@ class Ros2Supervisor(Node):
                 command = ['wslpath', '-w', relative_path_prefix]
                 relative_path_prefix = subprocess.check_output(command).strip().decode('utf-8').replace('\\', '/')
             if has_shared_folder() and relative_path_prefix:
-                components = relative_path_prefix.split(os.path.sep)
-                for i, component in enumerate(reversed(components)):
-                    if component == 'share':
-                        package_dir = os.path.sep.join(components[:-i + 1])
-                        resource_dir = os.path.sep.join(components[:-i + 2])
+                split_path = relative_path_prefix.split(os.path.sep)
+                for i, folder in (list(enumerate(split_path))):
+                    if folder == "share":
+                        package_dir = os.path.sep.join(split_path[:i + 2])
+                        resource_dir = os.path.sep.join(split_path[:i + 3])
                         break
                 shared_package_dir = os.path.join(container_shared_folder(), os.path.basename(package_dir))
                 shared_resource_dir = os.path.join(shared_package_dir, os.path.basename(resource_dir))
@@ -147,7 +147,7 @@ class Ros2Supervisor(Node):
                     os.mkdir(shared_package_dir)
                 if (not os.path.isdir(shared_resource_dir)):
                     shutil.copytree(resource_dir, shared_resource_dir)
-                relative_path_prefix = os.path.join(host_shared_folder(), os.path.basename(package_dir), os.path.basename(resource_dir))              
+                relative_path_prefix = os.path.join(host_shared_folder(), os.path.basename(package_dir), os.path.basename(resource_dir))
             robot_string = convertUrdfContent(input=robot.robot_description, robotName=robot_name, normal=normal,
                                               boxCollision=box_collision, initTranslation=robot_translation,
                                               initRotation=robot_rotation, initPos=init_pos,

--- a/webots_ros2_driver/webots_ros2_driver/ros2_supervisor.py
+++ b/webots_ros2_driver/webots_ros2_driver/ros2_supervisor.py
@@ -92,10 +92,7 @@ class Ros2Supervisor(Node):
 
         # Choose the conversion according to the input + adapt path in function of platform
         if robot.urdf_path:
-            if is_wsl():
-                command = ['wslpath', '-w', robot.urdf_path]
-                robot.urdf_path = subprocess.check_output(command).strip().decode('utf-8').replace('\\', '/')
-            if has_shared_folder():
+            if has_shared_folder() or is_wsl():
                 if not os.path.isfile(robot.urdf_path):
                     sys.exit('Input file "%s" does not exists.' % robot.urdf_path)
                 if not robot.urdf_path.endswith('.urdf'):
@@ -119,7 +116,9 @@ class Ros2Supervisor(Node):
                 if (not os.path.isdir(shared_resource_dir)):
                     shutil.copytree(resource_dir, shared_resource_dir)
                 relative_path_prefix = os.path.join(host_shared_folder(), os.path.basename(package_dir), os.path.basename(resource_dir))
-                self.get_logger().info(relative_path_prefix)
+                if is_wsl():
+                    command = ['wslpath', '-w', relative_path_prefix]
+                    relative_path_prefix = subprocess.check_output(command).strip().decode('utf-8').replace('\\', '/')
 
                 robot_string = convertUrdfContent(input=urdfContent, robotName=robot_name, normal=normal,
                                               boxCollision=box_collision, initTranslation=robot_translation,

--- a/webots_ros2_driver/webots_ros2_driver/ros2_supervisor.py
+++ b/webots_ros2_driver/webots_ros2_driver/ros2_supervisor.py
@@ -95,7 +95,7 @@ class Ros2Supervisor(Node):
             if has_shared_folder() or is_wsl():
                 # Check that the file exists and is an URDF
                 if not os.path.isfile(robot.urdf_path):
-                    sys.exit('Input file "%s" does not exists.' % robot.urdf_path)
+                    sys.exit('Input file "%s" does not exist.' % robot.urdf_path)
                 if not robot.urdf_path.endswith('.urdf'):
                     sys.exit('"%s" is not a URDF file.' % robot.urdf_path)
 

--- a/webots_ros2_driver/webots_ros2_driver/ros2_supervisor.py
+++ b/webots_ros2_driver/webots_ros2_driver/ros2_supervisor.py
@@ -109,14 +109,16 @@ class Ros2Supervisor(Node):
                         package_dir = os.path.sep.join(split_path[:i + 2])
                         resource_dir = os.path.sep.join(split_path[:i + 3])
                         break
-                shared_package_dir = os.path.join(container_shared_folder(), os.path.basename(package_dir))
-                shared_resource_dir = os.path.join(shared_package_dir, os.path.basename(resource_dir))
-                if (not os.path.isdir(shared_package_dir)):
-                    os.mkdir(shared_package_dir)
-                if (not os.path.isdir(shared_resource_dir)):
-                    shutil.copytree(resource_dir, shared_resource_dir)
-                relative_path_prefix = os.path.join(host_shared_folder(), os.path.basename(package_dir), os.path.basename(resource_dir))
+                if has_shared_folder():
+                    shared_package_dir = os.path.join(container_shared_folder(), os.path.basename(package_dir))
+                    shared_resource_dir = os.path.join(shared_package_dir, os.path.basename(resource_dir))
+                    if (not os.path.isdir(shared_package_dir)):
+                        os.mkdir(shared_package_dir)
+                    if (not os.path.isdir(shared_resource_dir)):
+                        shutil.copytree(resource_dir, shared_resource_dir)
+                    relative_path_prefix = os.path.join(host_shared_folder(), os.path.basename(package_dir), os.path.basename(resource_dir))
                 if is_wsl():
+                    relative_path_prefix = resource_dir
                     command = ['wslpath', '-w', relative_path_prefix]
                     relative_path_prefix = subprocess.check_output(command).strip().decode('utf-8').replace('\\', '/')
 

--- a/webots_ros2_driver/webots_ros2_driver/urdf_spawner.py
+++ b/webots_ros2_driver/webots_ros2_driver/urdf_spawner.py
@@ -16,12 +16,7 @@
 
 """This process simply sends urdf information to the Spawner through a service."""
 
-import os
-import shutil
-import subprocess
-
 from launch.actions import ExecuteProcess
-from webots_ros2_driver.utils import is_wsl, has_shared_folder, container_shared_folder, host_shared_folder
 
 
 def get_webots_driver_node(event, driver_node):
@@ -35,27 +30,6 @@ def get_webots_driver_node(event, driver_node):
 class URDFSpawner(ExecuteProcess):
     def __init__(self, output='log', name=None, urdf_path=None, robot_description=None, relative_path_prefix=None,
                  translation='0 0 0', rotation='0 0 1 0', normal=False, box_collision=False, init_pos=None, **kwargs):
-        if is_wsl() and relative_path_prefix:
-            command = ['wslpath', '-w', relative_path_prefix]
-            relative_path_prefix = subprocess.check_output(command).strip().decode('utf-8').replace('\\', '/')
-        if is_wsl() and urdf_path:
-            command = ['wslpath', '-w', urdf_path]
-            urdf_path = subprocess.check_output(command).strip().decode('utf-8').replace('\\', '/')
-        if has_shared_folder() and relative_path_prefix and not os.path.isdir(os.path.join(container_shared_folder(),
-                                                                              os.path.basename(relative_path_prefix))):
-            shutil.copytree(relative_path_prefix, os.path.join(container_shared_folder(),
-                            os.path.basename(relative_path_prefix)))
-            relative_path_prefix = os.path.join(host_shared_folder(), os.path.basename(relative_path_prefix))
-        if has_shared_folder() and relative_path_prefix:
-            components = urdf_path.split(os.path.sep)
-            for i, component in enumerate(reversed(components)):
-                if component == 'share':
-                    resource_dir = os.path.sep.join(components[:-i + 2])
-                    suffix = os.path.sep.join(components[-i + 2:])
-                    break
-            if (not os.path.isdir(os.path.join(container_shared_folder(), os.path.basename(resource_dir)))):
-                shutil.copytree(resource_dir, os.path.join(container_shared_folder(), os.path.basename(resource_dir)))
-                urdf_path = os.path.join(host_shared_folder(), suffix)
 
         message = '{robot: {'
 

--- a/webots_ros2_driver/webots_ros2_driver/urdf_spawner.py
+++ b/webots_ros2_driver/webots_ros2_driver/urdf_spawner.py
@@ -30,7 +30,6 @@ def get_webots_driver_node(event, driver_node):
 class URDFSpawner(ExecuteProcess):
     def __init__(self, output='log', name=None, urdf_path=None, robot_description=None, relative_path_prefix=None,
                  translation='0 0 0', rotation='0 0 1 0', normal=False, box_collision=False, init_pos=None, **kwargs):
-
         message = '{robot: {'
 
         if name:
@@ -57,14 +56,12 @@ class URDFSpawner(ExecuteProcess):
 
         message += '} }'
 
-        command = [
-                'ros2',
-                'service',
-                'call',
-                '/spawn_urdf_robot',
-                'webots_ros2_msgs/srv/SpawnUrdfRobot',
-                message
-            ]
+        command = ['ros2',
+                   'service',
+                   'call',
+                   '/spawn_urdf_robot',
+                   'webots_ros2_msgs/srv/SpawnUrdfRobot',
+                   message]
 
         super().__init__(
             output=output,

--- a/webots_ros2_driver/webots_ros2_driver/urdf_spawner.py
+++ b/webots_ros2_driver/webots_ros2_driver/urdf_spawner.py
@@ -38,11 +38,24 @@ class URDFSpawner(ExecuteProcess):
         if is_wsl() and relative_path_prefix:
             command = ['wslpath', '-w', relative_path_prefix]
             relative_path_prefix = subprocess.check_output(command).strip().decode('utf-8').replace('\\', '/')
-        if has_shared_folder() and relative_path_prefix and not os.path.isdir(
-          os.path.join(container_shared_folder(), os.path.basename(relative_path_prefix))):
+        if is_wsl() and urdf_path:
+            command = ['wslpath', '-w', urdf_path]
+            urdf_path = subprocess.check_output(command).strip().decode('utf-8').replace('\\', '/')
+        if has_shared_folder() and relative_path_prefix and not os.path.isdir(os.path.join(container_shared_folder(),
+                                                                              os.path.basename(relative_path_prefix))):
             shutil.copytree(relative_path_prefix, os.path.join(container_shared_folder(),
-                                                               os.path.basename(relative_path_prefix)))
+                            os.path.basename(relative_path_prefix)))
             relative_path_prefix = os.path.join(host_shared_folder(), os.path.basename(relative_path_prefix))
+        if has_shared_folder() and relative_path_prefix:
+            components = urdf_path.split(os.path.sep)
+            for i, component in enumerate(reversed(components)):
+                if component == 'share':
+                    resource_dir = os.path.sep.join(components[:-i + 2])
+                    suffix = os.path.sep.join(components[-i + 2:])
+                    break
+            if (not os.path.isdir(os.path.join(container_shared_folder(), os.path.basename(resource_dir)))):
+                shutil.copytree(resource_dir, os.path.join(container_shared_folder(), os.path.basename(resource_dir)))
+                urdf_path = os.path.join(host_shared_folder(), suffix)
 
         message = '{robot: {'
 

--- a/webots_ros2_epuck/CHANGELOG.rst
+++ b/webots_ros2_epuck/CHANGELOG.rst
@@ -2,7 +2,7 @@
 Changelog for package webots_ros2_epuck
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-2023.0.3 (2023-XX-XX)
+2023.0.2 (2023-XX-XX)
 ------------------
 * Updated supervisor launch.
 

--- a/webots_ros2_mavic/CHANGELOG.rst
+++ b/webots_ros2_mavic/CHANGELOG.rst
@@ -2,7 +2,7 @@
 Changelog for package webots_ros2_mavic
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-2023.0.3 (2023-XX-XX)
+2023.0.2 (2023-XX-XX)
 ------------------
 * Updated supervisor launch.
 

--- a/webots_ros2_tesla/CHANGELOG.rst
+++ b/webots_ros2_tesla/CHANGELOG.rst
@@ -2,7 +2,7 @@
 Changelog for package webots_ros2_tesla
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-2023.0.3 (2023-XX-XX)
+2023.0.2 (2023-XX-XX)
 ------------------
 * Updated supervisor launch.
 

--- a/webots_ros2_tiago/CHANGELOG.rst
+++ b/webots_ros2_tiago/CHANGELOG.rst
@@ -2,7 +2,7 @@
 Changelog for package webots_ros2_tiago
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-2023.0.3 (2023-XX-XX)
+2023.0.2 (2023-XX-XX)
 ------------------
 * Updated supervisor launch.
 

--- a/webots_ros2_turtlebot/CHANGELOG.rst
+++ b/webots_ros2_turtlebot/CHANGELOG.rst
@@ -2,7 +2,7 @@
 Changelog for package webots_ros2_turtlebot
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-2023.0.3 (2023-XX-XX)
+2023.0.2 (2023-XX-XX)
 ------------------
 * Updated supervisor launch.
 

--- a/webots_ros2_universal_robot/CHANGELOG.rst
+++ b/webots_ros2_universal_robot/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package webots_ros2_universal_robot
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2023.0.2 (2023-XX-XX)
+------------------
+* Fixed URDF relative URLs to assets.
+
 2022.1.3 (2022-11-02)
 ------------------
 * Added macOS support.

--- a/webots_ros2_universal_robot/resource/Universal_Robots_ROS2_Driver/ur_description/config/ur5e/visual_parameters.yaml
+++ b/webots_ros2_universal_robot/resource/Universal_Robots_ROS2_Driver/ur_description/config/ur5e/visual_parameters.yaml
@@ -1,67 +1,67 @@
 mesh_files:
   base:
     visual:
-      mesh: "package://resource/Universal_Robots_ROS2_Driver/ur_description/meshes/ur5e/visual/base.dae"
+      mesh: "package://webots_ros2_universal_robot/resource/Universal_Robots_ROS2_Driver/ur_description/meshes/ur5e/visual/base.dae"
       material:
         name: "LightGrey"
         color: "0.7 0.7 0.7 1.0"
     collision:
-      mesh: "package://resource/Universal_Robots_ROS2_Driver/ur_description/meshes/ur5e/collision/base.stl"
+      mesh: "package://webots_ros2_universal_robot/resource/Universal_Robots_ROS2_Driver/ur_description/meshes/ur5e/collision/base.stl"
 
   shoulder:
     visual:
-      mesh: "package://resource/Universal_Robots_ROS2_Driver/ur_description/meshes/ur5e/visual/shoulder.dae"
+      mesh: "package://webots_ros2_universal_robot/resource/Universal_Robots_ROS2_Driver/ur_description/meshes/ur5e/visual/shoulder.dae"
       material:
         name: "LightGrey"
         color: "0.7 0.7 0.7 1.0"
     collision:
-      mesh: "package://resource/Universal_Robots_ROS2_Driver/ur_description/meshes/ur5e/collision/shoulder.stl"
+      mesh: "package://webots_ros2_universal_robot/resource/Universal_Robots_ROS2_Driver/ur_description/meshes/ur5e/collision/shoulder.stl"
 
   upper_arm:
     visual:
-      mesh: "package://resource/Universal_Robots_ROS2_Driver/ur_description/meshes/ur5e/visual/upperarm.dae"
+      mesh: "package://webots_ros2_universal_robot/resource/Universal_Robots_ROS2_Driver/ur_description/meshes/ur5e/visual/upperarm.dae"
       material:
         name: "LightGrey"
         color: "0.7 0.7 0.7 1.0"
     collision:
-      mesh: "package://resource/Universal_Robots_ROS2_Driver/ur_description/meshes/ur5e/collision/upperarm.stl"
+      mesh: "package://webots_ros2_universal_robot/resource/Universal_Robots_ROS2_Driver/ur_description/meshes/ur5e/collision/upperarm.stl"
       mesh_files:
 
   forearm:
     visual:
-      mesh: "package://resource/Universal_Robots_ROS2_Driver/ur_description/meshes/ur5e/visual/forearm.dae"
+      mesh: "package://webots_ros2_universal_robot/resource/Universal_Robots_ROS2_Driver/ur_description/meshes/ur5e/visual/forearm.dae"
       material:
         name: "LightGrey"
         color: "0.7 0.7 0.7 1.0"
     collision:
-      mesh: "package://resource/Universal_Robots_ROS2_Driver/ur_description/meshes/ur5e/collision/forearm.stl"
+      mesh: "package://webots_ros2_universal_robot/resource/Universal_Robots_ROS2_Driver/ur_description/meshes/ur5e/collision/forearm.stl"
 
   wrist_1:
     visual:
-      mesh: "package://resource/Universal_Robots_ROS2_Driver/ur_description/meshes/ur5e/visual/wrist1.dae"
+      mesh: "package://webots_ros2_universal_robot/resource/Universal_Robots_ROS2_Driver/ur_description/meshes/ur5e/visual/wrist1.dae"
       material:
         name: "LightGrey"
         color: "0.7 0.7 0.7 1.0"
     collision:
-      mesh: "package://resource/Universal_Robots_ROS2_Driver/ur_description/meshes/ur5e/collision/wrist1.stl"
+      mesh: "package://webots_ros2_universal_robot/resource/Universal_Robots_ROS2_Driver/ur_description/meshes/ur5e/collision/wrist1.stl"
     visual_offset: -0.127
 
   wrist_2:
     visual:
-      mesh: "package://resource/Universal_Robots_ROS2_Driver/ur_description/meshes/ur5e/visual/wrist2.dae"
+      mesh: "package://webots_ros2_universal_robot/resource/Universal_Robots_ROS2_Driver/ur_description/meshes/ur5e/visual/wrist2.dae"
       material:
         name: "LightGrey"
         color: "0.7 0.7 0.7 1.0"
     collision:
-      mesh: "package://resource/Universal_Robots_ROS2_Driver/ur_description/meshes/ur5e/collision/wrist2.stl"
+      mesh: "package://webots_ros2_universal_robot/resource/Universal_Robots_ROS2_Driver/ur_description/meshes/ur5e/collision/wrist2.stl"
     visual_offset: -0.0997
 
   wrist_3:
     visual:
-      mesh: "package://resource/Universal_Robots_ROS2_Driver/ur_description/meshes/ur5e/visual/wrist3.dae"
+      mesh: "package://webots_ros2_universal_robot/resource/Universal_Robots_ROS2_Driver/ur_description/meshes/ur5e/visual/wrist3.dae"
       material:
         name: "LightGrey"
         color: "0.7 0.7 0.7 1.0"
     collision:
-      mesh: "package://resource/Universal_Robots_ROS2_Driver/ur_description/meshes/ur5e/collision/wrist3.stl"
+      mesh: "package://webots_ros2_universal_robot/resource/Universal_Robots_ROS2_Driver/ur_description/meshes/ur5e/collision/wrist3.stl"
     visual_offset: -0.0989

--- a/webots_ros2_universal_robot/resource/robotiq/robotiq_3f_gripper_visualization/cfg/robotiq-3f-gripper_articulated_macro.xacro
+++ b/webots_ros2_universal_robot/resource/robotiq/robotiq_3f_gripper_visualization/cfg/robotiq-3f-gripper_articulated_macro.xacro
@@ -16,7 +16,7 @@ there are multiple hands then a prefix followed by an "_" is needed.
 		<link name="${prefix}palm">
 			<visual>
 				<geometry>
-                                        <mesh filename="package://resource/robotiq/robotiq_3f_gripper_visualization/meshes/robotiq-3f-gripper_articulated/visual/palm.dae" />
+                                        <mesh filename="package://webots_ros2_universal_robot/resource/robotiq/robotiq_3f_gripper_visualization/meshes/robotiq-3f-gripper_articulated/visual/palm.dae" />
 				</geometry>
 				<material name="gray">
 					<color rgba="0.2 0.2 0.2 1"/>
@@ -24,7 +24,7 @@ there are multiple hands then a prefix followed by an "_" is needed.
 			</visual>
 			<collision>
 				<geometry>
-                                        <mesh filename="package://resource/robotiq/robotiq_3f_gripper_visualization/meshes/robotiq-3f-gripper_articulated/collision/palm.STL" />
+                                        <mesh filename="package://webots_ros2_universal_robot/resource/robotiq/robotiq_3f_gripper_visualization/meshes/robotiq-3f-gripper_articulated/collision/palm.STL" />
 				</geometry>
 				<material name="yellow">
 					<color rgba="0 1 1 1"/>

--- a/webots_ros2_universal_robot/resource/robotiq/robotiq_3f_gripper_visualization/cfg/robotiq-3f-gripper_finger_articulated_macro.xacro
+++ b/webots_ros2_universal_robot/resource/robotiq/robotiq_3f_gripper_visualization/cfg/robotiq-3f-gripper_finger_articulated_macro.xacro
@@ -13,7 +13,7 @@ finger(i.e. finger_1, etc...).
 			<visual>
 				<origin xyz="0.020 0 0" rpy="0 0 0"/>
 				<geometry>
-                                        <mesh filename="package://resource/robotiq/robotiq_3f_gripper_visualization/meshes/robotiq-3f-gripper_articulated/visual/link_0.dae" />
+                                        <mesh filename="package://webots_ros2_universal_robot/resource/robotiq/robotiq_3f_gripper_visualization/meshes/robotiq-3f-gripper_articulated/visual/link_0.dae" />
 				</geometry>
 				<material name="gray">
 					<color rgba="0.2 0.2 0.2 1"/>
@@ -22,7 +22,7 @@ finger(i.e. finger_1, etc...).
 			<collision>
 				<origin xyz="0.020 0 0" rpy="0 0 0"/>
 				<geometry>
-                                        <mesh filename="package://resource/robotiq/robotiq_3f_gripper_visualization/meshes/robotiq-3f-gripper_articulated/collision/link_0.STL" />
+                                        <mesh filename="package://webots_ros2_universal_robot/resource/robotiq/robotiq_3f_gripper_visualization/meshes/robotiq-3f-gripper_articulated/collision/link_0.STL" />
 				</geometry>
 				<material name="yellow">
 					<color rgba="0 1 1 1"/>
@@ -38,14 +38,14 @@ finger(i.e. finger_1, etc...).
 			<visual>
 				<origin xyz="0.050 -.028 0" rpy="0 0 -0.52"/>
 				<geometry>
-                                        <mesh filename="package://resource/robotiq/robotiq_3f_gripper_visualization/meshes/robotiq-3f-gripper_articulated/visual/link_1.dae" />
+                                        <mesh filename="package://webots_ros2_universal_robot/resource/robotiq/robotiq_3f_gripper_visualization/meshes/robotiq-3f-gripper_articulated/visual/link_1.dae" />
 				</geometry>
 				<material name="gray"/>
 			</visual>
 			<collision>
 				<origin xyz="0.050 -.028 0" rpy="0 0 -0.52"/>
 				<geometry>
-                                        <mesh filename="package://resource/robotiq/robotiq_3f_gripper_visualization/meshes/robotiq-3f-gripper_articulated/collision/link_1.STL" />
+                                        <mesh filename="package://webots_ros2_universal_robot/resource/robotiq/robotiq_3f_gripper_visualization/meshes/robotiq-3f-gripper_articulated/collision/link_1.STL" />
 				</geometry>
 				<material name="yellow"/>
 			</collision>
@@ -64,14 +64,14 @@ finger(i.e. finger_1, etc...).
 			<visual>
 				<origin xyz="0.039 0 0.0075" rpy="0 0 0"/>
 				<geometry>
-                                        <mesh filename="package://resource/robotiq/robotiq_3f_gripper_visualization/meshes/robotiq-3f-gripper_articulated/visual/link_2.dae" />
+                                        <mesh filename="package://webots_ros2_universal_robot/resource/robotiq/robotiq_3f_gripper_visualization/meshes/robotiq-3f-gripper_articulated/visual/link_2.dae" />
 				</geometry>
 				<material name="gray"/>
 			</visual>
 			<collision>
 				<origin xyz="0.039 0 0.0075" rpy="0 0 0"/>
 				<geometry>
-                                        <mesh filename="package://resource/robotiq/robotiq_3f_gripper_visualization/meshes/robotiq-3f-gripper_articulated/collision/link_2.STL" />
+                                        <mesh filename="package://webots_ros2_universal_robot/resource/robotiq/robotiq_3f_gripper_visualization/meshes/robotiq-3f-gripper_articulated/collision/link_2.STL" />
 				</geometry>
 				<material name="yellow"/>
 			</collision>
@@ -85,14 +85,14 @@ finger(i.e. finger_1, etc...).
 			<visual>
 				<origin xyz="0 0 0" rpy="0 0 0.52"/>
 				<geometry>
-                                        <mesh filename="package://resource/robotiq/robotiq_3f_gripper_visualization/meshes/robotiq-3f-gripper_articulated/visual/link_3.dae" />
+                                        <mesh filename="package://webots_ros2_universal_robot/resource/robotiq/robotiq_3f_gripper_visualization/meshes/robotiq-3f-gripper_articulated/visual/link_3.dae" />
 				</geometry>
 				<material name="gray"/>
 			</visual>
 			<collision>
 				<origin xyz="0 0 0" rpy="0 0 0.52"/>
 				<geometry>
-                                        <mesh filename="package://resource/robotiq/robotiq_3f_gripper_visualization/meshes/robotiq-3f-gripper_articulated/collision/link_3.STL" />
+                                        <mesh filename="package://webots_ros2_universal_robot/resource/robotiq/robotiq_3f_gripper_visualization/meshes/robotiq-3f-gripper_articulated/collision/link_3.STL" />
 				</geometry>
 				<material name="yellow"/>
 			</collision>


### PR DESCRIPTION
Fixes #558 and #581.

## **#581** ##

URDFs can be spawned in 2 different ways:
- By giving the complete robot description and the path to the resources as a prefix to append to assets relative URLs.
- By giving only the path to the URDF file.

The first way was correctly handled on WSL and macOS. The second one was not and is trickier, as the path must be kept to open the file on the Linux side, while the URL should be edited to be compatible with WSL and the shared directory, respectively on Windows and macOS.

To counter this problem, on Windows and macOS, the URDF file is opened by the `ROS2_supervisor` and is passed as the robot description, and the path prefix is set according to the URDF path by searching for the 'share' directory.

The URL edition is now completely done in the supervisor, for clarity.

## **#558** ##

The URLs of xacro files in the universal robot example are reverted to the correct RVIZ format. To fix the issue on macOS, the resource folder is now copied inside another folder that has the same name as the package, to be consistent with the Rviz structure.