### PR TITLE
Fix macOS local assets with relative URLs

### DIFF
--- a/webots_ros2/CHANGELOG.rst
+++ b/webots_ros2/CHANGELOG.rst
@@ -5,6 +5,7 @@ Changelog for package webots_ros2
 2023.0.2 (2023-XX-XX)
 ------------------
 * Drop support for Galactic.
+* Fixed relative assets in macOS.
 
 2023.0.1 (2023-01-05)
 ------------------

--- a/webots_ros2_driver/CHANGELOG.rst
+++ b/webots_ros2_driver/CHANGELOG.rst
@@ -2,9 +2,13 @@
 Changelog for package webots_ros2_driver
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2023.0.2 (2023-XX-XX)
+------------------
+* Fixed relative assets in macOS.
+
 2023.0.1 (2023-01-05)
 ------------------
-* Fix relative assets in WSL.
+* Fixed relative assets in WSL.
 
 2023.0.0 (2022-11-30)
 ------------------

--- a/webots_ros2_driver/webots_ros2_driver/webots_launcher.py
+++ b/webots_ros2_driver/webots_ros2_driver/webots_launcher.py
@@ -36,6 +36,7 @@ from webots_ros2_driver.utils import (get_webots_home,
                                       is_wsl,
                                       has_shared_folder,
                                       container_shared_folder,
+                                      host_shared_folder,
                                       controller_url_prefix)
 
 
@@ -161,6 +162,10 @@ class WebotsLauncher(ExecuteProcess):
                 continue
 
             new_url_path = os.path.split(world_path)[0] + '/' + url_path
+            if self.__has_shared_folder:
+                # Copy asset to shared folder
+                shutil.copy(new_url_path, os.path.join(container_shared_folder(), os.path.basename(new_url_path)))
+                new_url_path = './' + os.path.basename(new_url_path)
             if self.__is_wsl:
                 command = ['wslpath', '-w', new_url_path]
                 new_url_path = subprocess.check_output(command).strip().decode('utf-8').replace('\\', '/')

--- a/webots_ros2_driver/webots_ros2_driver/webots_launcher.py
+++ b/webots_ros2_driver/webots_ros2_driver/webots_launcher.py
@@ -36,7 +36,6 @@ from webots_ros2_driver.utils import (get_webots_home,
                                       is_wsl,
                                       has_shared_folder,
                                       container_shared_folder,
-                                      host_shared_folder,
                                       controller_url_prefix)
 
 


### PR DESCRIPTION
Fixes #583.

The local assets referenced with relative URL in the world files are copied to the shared folder on macOS. Their URL is also updated to reflect the new relative path to the world.