### PR TITLE
Optional Ros2 Supervisor

### DIFF
--- a/webots_ros2/CHANGELOG.rst
+++ b/webots_ros2/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package webots_ros2
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2023.0.3 (2023-XX-XX)
+------------------
+* Ros2Supervisor is now optional.
+
 2023.0.2 (2023-XX-XX)
 ------------------
 * Drop support for Galactic.

--- a/webots_ros2_driver/CHANGELOG.rst
+++ b/webots_ros2_driver/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package webots_ros2_driver
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2023.0.3 (2023-XX-XX)
+------------------
+* Added Ros2Supervisor creation.
+
 2023.0.2 (2023-XX-XX)
 ------------------
 * Fixed relative assets in macOS.

--- a/webots_ros2_driver/webots_ros2_driver/webots_launcher.py
+++ b/webots_ros2_driver/webots_ros2_driver/webots_launcher.py
@@ -23,7 +23,6 @@ import subprocess
 import sys
 import tempfile
 
-import launch
 from launch.actions import ExecuteProcess
 from launch_ros.actions import Node
 from launch.launch_context import LaunchContext

--- a/webots_ros2_driver/webots_ros2_driver/webots_launcher.py
+++ b/webots_ros2_driver/webots_ros2_driver/webots_launcher.py
@@ -23,6 +23,7 @@ import subprocess
 import sys
 import tempfile
 
+import launch
 from launch.actions import ExecuteProcess
 from launch_ros.actions import Node
 from launch.launch_context import LaunchContext
@@ -52,7 +53,7 @@ class _ConditionalSubstitution(Substitution):
 
 
 class WebotsLauncher(ExecuteProcess):
-    def __init__(self, output='screen', world=None, gui=True, mode='realtime', stream=False, **kwargs):
+    def __init__(self, output='screen', world=None, gui=True, mode='realtime', stream=False, ros2_supervisor=False, **kwargs):
         if sys.platform == 'win32':
             print('WARNING: Native webots_ros2 compatibility with Windows is deprecated and will be removed soon. Please use a '
                   'WSL (Windows Subsystem for Linux) environment instead.', file=sys.stderr)
@@ -60,6 +61,9 @@ class WebotsLauncher(ExecuteProcess):
                   'information.', file=sys.stderr)
         self.__is_wsl = is_wsl()
         self.__has_shared_folder = has_shared_folder()
+        self.__is_supervisor = ros2_supervisor
+        if self.__is_supervisor:
+            self._supervisor = Ros2SupervisorLauncher()
 
         # Find Webots executable
         if not self.__has_shared_folder:
@@ -176,14 +180,15 @@ class WebotsLauncher(ExecuteProcess):
             file.write(content)
 
         # Add the Ros2Supervisor
-        indent = '  '
-        world_file = open(self.__world_copy.name, 'a')
-        world_file.write('Robot {\n')
-        world_file.write(indent + 'name "Ros2Supervisor"\n')
-        world_file.write(indent + 'controller "<extern>"\n')
-        world_file.write(indent + 'supervisor TRUE\n')
-        world_file.write('}\n')
-        world_file.close()
+        if self.__is_supervisor:
+            indent = '  '
+            world_file = open(self.__world_copy.name, 'a')
+            world_file.write('Robot {\n')
+            world_file.write(indent + 'name "Ros2Supervisor"\n')
+            world_file.write(indent + 'controller "<extern>"\n')
+            world_file.write(indent + 'supervisor TRUE\n')
+            world_file.write('}\n')
+            world_file.close()
 
         # Copy world file to shared folder
         if self.__has_shared_folder:

--- a/webots_ros2_epuck/CHANGELOG.rst
+++ b/webots_ros2_epuck/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package webots_ros2_epuck
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2023.0.3 (2023-XX-XX)
+------------------
+* Updated supervisor launch.
+
 2023.0.1 (2023-01-05)
 ------------------
 * Fixed broken controller connection in Rats life example.

--- a/webots_ros2_epuck/launch/robot_launch.py
+++ b/webots_ros2_epuck/launch/robot_launch.py
@@ -25,7 +25,7 @@ from launch.substitutions.path_join_substitution import PathJoinSubstitution
 from launch_ros.actions import Node
 from launch import LaunchDescription
 from ament_index_python.packages import get_package_share_directory
-from webots_ros2_driver.webots_launcher import WebotsLauncher, Ros2SupervisorLauncher
+from webots_ros2_driver.webots_launcher import WebotsLauncher
 from webots_ros2_driver.utils import controller_url_prefix
 
 
@@ -119,16 +119,15 @@ def generate_launch_description():
     world = LaunchConfiguration('world')
 
     webots = WebotsLauncher(
-        world=PathJoinSubstitution([package_dir, 'worlds', world])
+        world=PathJoinSubstitution([package_dir, 'worlds', world]),
+        ros2_supervisor=True
     )
-
-    ros2_supervisor = Ros2SupervisorLauncher()
 
     # The following line is important!
     # This event handler respawns the ROS 2 nodes on simulation reset (supervisor process ends).
     reset_handler = launch.actions.RegisterEventHandler(
         event_handler=launch.event_handlers.OnProcessExit(
-            target_action=ros2_supervisor,
+            target_action=webots._supervisor,
             on_exit=get_ros2_nodes,
         )
     )
@@ -140,7 +139,7 @@ def generate_launch_description():
             description='Choose one of the world files from `/webots_ros2_epuck/world` directory'
         ),
         webots,
-        ros2_supervisor,
+        webots._supervisor,
 
         # This action will kill all nodes once the Webots simulation has exited
         launch.actions.RegisterEventHandler(

--- a/webots_ros2_mavic/CHANGELOG.rst
+++ b/webots_ros2_mavic/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package webots_ros2_mavic
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2023.0.3 (2023-XX-XX)
+------------------
+* Updated supervisor launch.
+
 2022.1.3 (2022-11-02)
 ------------------
 * Added macOS support.

--- a/webots_ros2_mavic/launch/robot_launch.py
+++ b/webots_ros2_mavic/launch/robot_launch.py
@@ -25,7 +25,7 @@ from launch.substitutions.path_join_substitution import PathJoinSubstitution
 from launch_ros.actions import Node
 from launch import LaunchDescription
 from ament_index_python.packages import get_package_share_directory
-from webots_ros2_driver.webots_launcher import WebotsLauncher, Ros2SupervisorLauncher
+from webots_ros2_driver.webots_launcher import WebotsLauncher
 from webots_ros2_driver.utils import controller_url_prefix
 
 
@@ -53,16 +53,15 @@ def generate_launch_description():
     world = LaunchConfiguration('world')
 
     webots = WebotsLauncher(
-        world=PathJoinSubstitution([package_dir, 'worlds', world])
+        world=PathJoinSubstitution([package_dir, 'worlds', world]),
+        ros2_supervisor=True
     )
-
-    ros2_supervisor = Ros2SupervisorLauncher()
 
     # The following line is important!
     # This event handler respawns the ROS 2 nodes on simulation reset (supervisor process ends).
     reset_handler = launch.actions.RegisterEventHandler(
         event_handler=launch.event_handlers.OnProcessExit(
-            target_action=ros2_supervisor,
+            target_action=webots._supervisor,
             on_exit=get_ros2_nodes,
         )
     )
@@ -74,7 +73,7 @@ def generate_launch_description():
             description='Choose one of the world files from `/webots_ros2_mavic/worlds` directory'
         ),
         webots,
-        ros2_supervisor,
+        webots._supervisor,
 
         # This action will kill all nodes once the Webots simulation has exited
         launch.actions.RegisterEventHandler(

--- a/webots_ros2_tesla/CHANGELOG.rst
+++ b/webots_ros2_tesla/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package webots_ros2_tesla
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2023.0.3 (2023-XX-XX)
+------------------
+* Updated supervisor launch.
+
 2022.1.3 (2022-11-02)
 ------------------
 * Added macOS support.

--- a/webots_ros2_tesla/launch/robot_launch.py
+++ b/webots_ros2_tesla/launch/robot_launch.py
@@ -25,7 +25,7 @@ from launch.substitutions.path_join_substitution import PathJoinSubstitution
 from launch import LaunchDescription
 from ament_index_python.packages import get_package_share_directory
 from launch_ros.actions import Node
-from webots_ros2_driver.webots_launcher import WebotsLauncher, Ros2SupervisorLauncher
+from webots_ros2_driver.webots_launcher import WebotsLauncher
 from webots_ros2_driver.utils import controller_url_prefix
 
 
@@ -59,16 +59,15 @@ def generate_launch_description():
     world = LaunchConfiguration('world')
 
     webots = WebotsLauncher(
-        world=PathJoinSubstitution([package_dir, 'worlds', world])
+        world=PathJoinSubstitution([package_dir, 'worlds', world]),
+        ros2_supervisor=True
     )
-
-    ros2_supervisor = Ros2SupervisorLauncher()
 
     # The following line is important!
     # This event handler respawns the ROS 2 nodes on simulation reset (supervisor process ends).
     reset_handler = launch.actions.RegisterEventHandler(
         event_handler=launch.event_handlers.OnProcessExit(
-            target_action=ros2_supervisor,
+            target_action=webots._supervisor,
             on_exit=get_ros2_nodes,
         )
     )
@@ -80,7 +79,7 @@ def generate_launch_description():
             description='Choose one of the world files from `/webots_ros2_tesla/worlds` directory'
         ),
         webots,
-        ros2_supervisor,
+        webots._supervisor,
 
         # This action will kill all nodes once the Webots simulation has exited
         launch.actions.RegisterEventHandler(

--- a/webots_ros2_tiago/CHANGELOG.rst
+++ b/webots_ros2_tiago/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package webots_ros2_tiago
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2023.0.3 (2023-XX-XX)
+------------------
+* Updated supervisor launch.
+
 2022.1.3 (2022-11-02)
 ------------------
 * Added macOS support.

--- a/webots_ros2_tiago/launch/robot_launch.py
+++ b/webots_ros2_tiago/launch/robot_launch.py
@@ -27,7 +27,7 @@ from launch_ros.actions import Node
 from ament_index_python.packages import get_package_share_directory, get_packages_with_prefixes
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.actions import IncludeLaunchDescription
-from webots_ros2_driver.webots_launcher import WebotsLauncher, Ros2SupervisorLauncher
+from webots_ros2_driver.webots_launcher import WebotsLauncher
 from webots_ros2_driver.utils import controller_url_prefix
 
 
@@ -144,16 +144,15 @@ def generate_launch_description():
 
     webots = WebotsLauncher(
         world=PathJoinSubstitution([package_dir, 'worlds', world]),
-        mode=mode
+        mode=mode,
+        ros2_supervisor=True
     )
-
-    ros2_supervisor = Ros2SupervisorLauncher()
 
     # The following line is important!
     # This event handler respawns the ROS 2 nodes on simulation reset (supervisor process ends).
     reset_handler = launch.actions.RegisterEventHandler(
         event_handler=launch.event_handlers.OnProcessExit(
-            target_action=ros2_supervisor,
+            target_action=webots._supervisor,
             on_exit=get_ros2_nodes,
         )
     )
@@ -170,7 +169,7 @@ def generate_launch_description():
             description='Webots startup mode'
         ),
         webots,
-        ros2_supervisor,
+        webots._supervisor,
 
         # This action will kill all nodes once the Webots simulation has exited
         launch.actions.RegisterEventHandler(

--- a/webots_ros2_turtlebot/CHANGELOG.rst
+++ b/webots_ros2_turtlebot/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package webots_ros2_turtlebot
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2023.0.3 (2023-XX-XX)
+------------------
+* Updated supervisor launch.
+
 2022.1.3 (2022-11-02)
 ------------------
 * Added macOS support.

--- a/webots_ros2_turtlebot/launch/robot_launch.py
+++ b/webots_ros2_turtlebot/launch/robot_launch.py
@@ -25,7 +25,7 @@ from launch import LaunchDescription
 from launch_ros.actions import Node
 import launch
 from ament_index_python.packages import get_package_share_directory
-from webots_ros2_driver.webots_launcher import WebotsLauncher, Ros2SupervisorLauncher
+from webots_ros2_driver.webots_launcher import WebotsLauncher
 from webots_ros2_driver.utils import controller_url_prefix
 
 
@@ -105,16 +105,15 @@ def generate_launch_description():
     world = LaunchConfiguration('world')
 
     webots = WebotsLauncher(
-        world=PathJoinSubstitution([package_dir, 'worlds', world])
+        world=PathJoinSubstitution([package_dir, 'worlds', world]),
+        ros2_supervisor=True
     )
-
-    ros2_supervisor = Ros2SupervisorLauncher()
 
     # The following line is important!
     # This event handler respawns the ROS 2 nodes on simulation reset (supervisor process ends).
     reset_handler = launch.actions.RegisterEventHandler(
         event_handler=launch.event_handlers.OnProcessExit(
-            target_action=ros2_supervisor,
+            target_action=webots._supervisor,
             on_exit=get_ros2_nodes,
         )
     )
@@ -126,7 +125,7 @@ def generate_launch_description():
             description='Choose one of the world files from `/webots_ros2_turtlebot/world` directory'
         ),
         webots,
-        ros2_supervisor,
+        webots._supervisor,
 
         # This action will kill all nodes once the Webots simulation has exited
         launch.actions.RegisterEventHandler(

--- a/webots_ros2_universal_robot/CHANGELOG.rst
+++ b/webots_ros2_universal_robot/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package webots_ros2_universal_robot
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2023.0.3 (2023-XX-XX)
+------------------
+* Updated supervisor launch.
+
 2022.1.3 (2022-11-02)
 ------------------
 * Added macOS support.

--- a/webots_ros2_universal_robot/launch/multirobot_launch.py
+++ b/webots_ros2_universal_robot/launch/multirobot_launch.py
@@ -27,7 +27,7 @@ from launch.substitutions import LaunchConfiguration
 from launch.substitutions.path_join_substitution import PathJoinSubstitution
 from launch_ros.actions import Node
 from webots_ros2_driver.urdf_spawner import URDFSpawner, get_webots_driver_node
-from webots_ros2_driver.webots_launcher import WebotsLauncher, Ros2SupervisorLauncher
+from webots_ros2_driver.webots_launcher import WebotsLauncher
 from webots_ros2_driver.utils import controller_url_prefix
 
 
@@ -164,17 +164,15 @@ def generate_launch_description():
 
     # Starts Webots
     webots = WebotsLauncher(
-        world=PathJoinSubstitution([package_dir, 'worlds', world])
+        world=PathJoinSubstitution([package_dir, 'worlds', world]),
+        ros2_supervisor=True
     )
-
-    # Starts the Ros2Supervisor node, with by default respawn=True
-    ros2_supervisor = Ros2SupervisorLauncher()
 
     # The following line is important!
     # This event handler respawns the ROS 2 nodes on simulation reset (supervisor process ends).
     reset_handler = launch.actions.RegisterEventHandler(
         event_handler=launch.event_handlers.OnProcessExit(
-            target_action=ros2_supervisor,
+            target_action=webots._supervisor,
             on_exit=get_ros2_nodes,
         )
     )
@@ -186,7 +184,7 @@ def generate_launch_description():
             description='Choose one of the world files from `/webots_ros2_universal_robot/worlds` directory'
         ),
         webots,
-        ros2_supervisor,
+        webots._supervisor,
 
         # This action will kill all nodes once the Webots simulation has exited
         launch.actions.RegisterEventHandler(

--- a/webots_ros2_universal_robot/launch/robot_launch/robot_world_launch.py
+++ b/webots_ros2_universal_robot/launch/robot_launch/robot_world_launch.py
@@ -22,7 +22,7 @@ from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration
 from launch.substitutions.path_join_substitution import PathJoinSubstitution
-from webots_ros2_driver.webots_launcher import WebotsLauncher, Ros2SupervisorLauncher
+from webots_ros2_driver.webots_launcher import WebotsLauncher
 
 
 PACKAGE_NAME = 'webots_ros2_universal_robot'
@@ -34,11 +34,9 @@ def generate_launch_description():
 
     # Starts Webots
     webots = WebotsLauncher(
-        world=PathJoinSubstitution([package_dir, 'worlds', world])
+        world=PathJoinSubstitution([package_dir, 'worlds', world]),
+        ros2_supervisor=True
     )
-
-    # Starts the Ros2Supervisor node, with by default respawn=True
-    ros2_supervisor = Ros2SupervisorLauncher()
 
     return LaunchDescription([
         DeclareLaunchArgument(
@@ -47,7 +45,7 @@ def generate_launch_description():
             description='Choose one of the world files from `/webots_ros2_universal_robot/worlds` directory'
         ),
         webots,
-        ros2_supervisor,
+        webots._supervisor,
         # This action will kill all nodes once the Webots simulation has exited
         launch.actions.RegisterEventHandler(
             event_handler=launch.event_handlers.OnProcessExit(


### PR DESCRIPTION
Resolves #509.

The Ros2 supervisor is now optional and is created by the WebotsLauncher Node. The supervisor node can still be used in the launch file if necessary. 

If the Ros2 supervisor is created, it still must figure in the launch description of the launch file, so that it gets started with other nodes.
