### PR TITLE
adding possibility to select stream type

### DIFF
--- a/webots_ros2_driver/webots_ros2_driver/webots_launcher.py
+++ b/webots_ros2_driver/webots_ros2_driver/webots_launcher.py
@@ -92,7 +92,12 @@ class WebotsLauncher(ExecuteProcess):
         stdout = _ConditionalSubstitution(condition=gui, false_value='--stdout')
         stderr = _ConditionalSubstitution(condition=gui, false_value='--stderr')
         minimize = _ConditionalSubstitution(condition=gui, false_value='--minimize')
-        stream_argument = _ConditionalSubstitution(condition=stream, true_value='--stream')
+        stream_argument = "",
+        if isinstance(stream, bool):
+            stream_argument = _ConditionalSubstitution(condition=stream, true_value='--stream')
+        else:
+            stream_argument = "--stream="+stream
+
         xvfb_run_prefix = []
 
         if 'WEBOTS_OFFSCREEN' in os.environ:


### PR DESCRIPTION
**Description**
The webots_laucher does not support the selection of the streaming type. You can only enable or disable a stream. This pull request enables the user to select the stream type (x3d or mjpeg). It still allows the usage of booleans as parameter. Therefore, it is backwards compatible with the old interface. However, you can not provide a string instead of a boolean to select the type.

**Related Issues**
none

**Affected Packages**
List of affected packages:
  - webots_ros2_driver



