### PR TITLE
Update sync_controller_lib.sh to copy version.txt

### DIFF
--- a/scripts/sync_controller_lib.sh
+++ b/scripts/sync_controller_lib.sh
@@ -52,6 +52,7 @@ mkdir -p resources/projects/libraries/generic_robot_window
 cp -r ${WEBOTS_HOME}/resources/projects/libraries/generic_robot_window/* resources/projects/libraries/generic_robot_window
 cp ${WEBOTS_HOME}/resources/Makefile.include resources
 cp ${WEBOTS_HOME}/resources/Makefile.os.include resources
+cp ${WEBOTS_HOME}/resources/version.txt resources
 
 rm -rf src
 mkdir -p src/controller


### PR DESCRIPTION
With the update of the libController (https://github.com/cyberbotics/webots/pull/5896) to check the version against the one from Webots, the `version.txt` file is needed for compilation.