### PR TITLE
Adding port parameter and usage of webots world project file to launcher.py

### DIFF
--- a/webots_ros2/CHANGELOG.rst
+++ b/webots_ros2/CHANGELOG.rst
@@ -8,6 +8,8 @@ Changelog for package webots_ros2
 * Fixed the spawn of URDF robots in WSL and macOS when using full path.
 * Fixed relative assets in macOS.
 * Ros2Supervisor is now optional.
+* Adding port, stream type parameters to webots_laucher
+* Copying .wbproj when launching a webots world via webots_launcher
 
 2023.0.1 (2023-01-05)
 ------------------

--- a/webots_ros2/CHANGELOG.rst
+++ b/webots_ros2/CHANGELOG.rst
@@ -2,14 +2,17 @@
 Changelog for package webots_ros2
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2023.0.3 (2023-XX-XX)
+------------------
+* Adding port, stream type parameters to webots_laucher
+* Copying .wbproj when launching a Webots world via webots_launcher
+
 2023.0.2 (2023-02-07)
 ------------------
 * Drop support for Galactic.
 * Fixed the spawn of URDF robots in WSL and macOS when using full path.
 * Fixed relative assets in macOS.
 * Ros2Supervisor is now optional.
-* Adding port, stream type parameters to webots_laucher
-* Copying .wbproj when launching a webots world via webots_launcher
 
 2023.0.1 (2023-01-05)
 ------------------

--- a/webots_ros2_driver/CHANGELOG.rst
+++ b/webots_ros2_driver/CHANGELOG.rst
@@ -1,6 +1,10 @@
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Changelog for package webots_ros2_driver
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+2023.0.3
+------------------
+* Adding port, stream type parameters to webots_laucher
+* Copying .wbproj when launching a webots world via webots_launcher
 
 2023.0.2 (2023-02-07)
 ------------------

--- a/webots_ros2_driver/CHANGELOG.rst
+++ b/webots_ros2_driver/CHANGELOG.rst
@@ -1,7 +1,8 @@
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Changelog for package webots_ros2_driver
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-2023.0.3
+2023.0.3 (2023-XX-XX)
 ------------------
 * Adding port, stream type parameters to webots_laucher
 * Copying .wbproj when launching a webots world via webots_launcher

--- a/webots_ros2_driver/webots_ros2_driver/utils.py
+++ b/webots_ros2_driver/webots_ros2_driver/utils.py
@@ -135,9 +135,9 @@ def get_host_ip():
         sys.exit('Unable to get host IP address. \'ip route\' could not be executed.')
 
 
-def controller_url_prefix():
+def controller_url_prefix(port="1234"):
     if has_shared_folder() or is_wsl():
-        return 'tcp://' + (get_host_ip() if has_shared_folder() else get_wsl_ip_address()) + ':1234/'
+        return 'tcp://' + (get_host_ip() if has_shared_folder() else get_wsl_ip_address()) + ':' + port + '/'
     else:
         return ''
 

--- a/webots_ros2_driver/webots_ros2_driver/utils.py
+++ b/webots_ros2_driver/webots_ros2_driver/utils.py
@@ -135,7 +135,7 @@ def get_host_ip():
         sys.exit('Unable to get host IP address. \'ip route\' could not be executed.')
 
 
-def controller_url_prefix(port="1234"):
+def controller_url_prefix(port='1234'):
     if has_shared_folder() or is_wsl():
         return 'tcp://' + (get_host_ip() if has_shared_folder() else get_wsl_ip_address()) + ':' + port + '/'
     else:

--- a/webots_ros2_driver/webots_ros2_driver/webots_launcher.py
+++ b/webots_ros2_driver/webots_ros2_driver/webots_launcher.py
@@ -161,14 +161,11 @@ class WebotsLauncher(ExecuteProcess):
         shutil.copy2(world_path, self.__world_copy.name)
 
         # look for a wbproj file and copy if available
-        wbproj_path = Path(world_path)
-        wbproj_path = wbproj_path.with_suffix('.wbproj')
-        wbproj_path = wbproj_path.with_name("."+wbproj_path.name)
+        wbproj_path = Path(world_path).with_name('.' + Path(world_path).stem + '.wbproj')
 
         if wbproj_path.exists():
-            wbproj_copy_path = Path(self.__world_copy.name)
-            wbproj_copy_path = wbproj_copy_path.with_suffix('.wbproj')
-            wbproj_copy_path = wbproj_copy_path.with_name("."+wbproj_copy_path.name)
+            wbproj_copy_path = Path(self.__world_copy.name).with_name('.' + Path(self.__world_copy.name).stem +
+                                                                      '.wbproj')
             shutil.copy2(wbproj_path, wbproj_copy_path)
 
         # Update relative paths in the world
@@ -211,8 +208,11 @@ class WebotsLauncher(ExecuteProcess):
 
         # Copy world file to shared folder
         if self.__has_shared_folder:
-            shutil.copy(self.__world_copy.name, os.path.join(container_shared_folder(),
-                                                             os.path.basename(self.__world_copy.name)))
+            shared_world_file = os.path.join(container_shared_folder(), os.path.basename(self.__world_copy.name))
+            shutil.copy(self.__world_copy.name, shared_world_file)
+            if wbproj_path.exists():
+                shared_wbproj_copy_path = Path(shared_world_file).with_name('.' + Path(shared_world_file).stem + '.wbproj')
+                shutil.copy(wbproj_path, shared_wbproj_copy_path)
 
         # Execute process
         return super().execute(context)
@@ -245,7 +245,7 @@ class WebotsLauncher(ExecuteProcess):
 
 
 class Ros2SupervisorLauncher(Node):
-    def __init__(self, output='screen', respawn=True, **kwargs):
+    def __init__(self, output='screen', respawn=True, port="1234", **kwargs):
         # Launch the Ros2Supervisor node
         super().__init__(
             package='webots_ros2_driver',
@@ -253,7 +253,7 @@ class Ros2SupervisorLauncher(Node):
             output=output,
             # Set WEBOTS_HOME to the webots_ros2_driver installation folder
             # to load the correct libController libraries from the Python API
-            additional_env={'WEBOTS_CONTROLLER_URL': controller_url_prefix() + 'Ros2Supervisor',
+            additional_env={'WEBOTS_CONTROLLER_URL': controller_url_prefix(port) + 'Ros2Supervisor',
                             'WEBOTS_HOME': get_package_prefix('webots_ros2_driver')},
             respawn=respawn,
             **kwargs

--- a/webots_ros2_driver/webots_ros2_driver/webots_launcher.py
+++ b/webots_ros2_driver/webots_ros2_driver/webots_launcher.py
@@ -245,7 +245,7 @@ class WebotsLauncher(ExecuteProcess):
 
 
 class Ros2SupervisorLauncher(Node):
-    def __init__(self, output='screen', respawn=True, port="1234", **kwargs):
+    def __init__(self, output='screen', respawn=True, port='1234', **kwargs):
         # Launch the Ros2Supervisor node
         super().__init__(
             package='webots_ros2_driver',

--- a/webots_ros2_driver/webots_ros2_driver/webots_launcher.py
+++ b/webots_ros2_driver/webots_ros2_driver/webots_launcher.py
@@ -92,11 +92,10 @@ class WebotsLauncher(ExecuteProcess):
         stdout = _ConditionalSubstitution(condition=gui, false_value='--stdout')
         stderr = _ConditionalSubstitution(condition=gui, false_value='--stderr')
         minimize = _ConditionalSubstitution(condition=gui, false_value='--minimize')
-        stream_argument = "",
         if isinstance(stream, bool):
             stream_argument = _ConditionalSubstitution(condition=stream, true_value='--stream')
         else:
-            stream_argument = "--stream="+stream
+            stream_argument = "--stream=" + stream
 
         xvfb_run_prefix = []
 

--- a/webots_ros2_driver/webots_ros2_driver/webots_launcher.py
+++ b/webots_ros2_driver/webots_ros2_driver/webots_launcher.py
@@ -92,7 +92,12 @@ class WebotsLauncher(ExecuteProcess):
         stdout = _ConditionalSubstitution(condition=gui, false_value='--stdout')
         stderr = _ConditionalSubstitution(condition=gui, false_value='--stderr')
         minimize = _ConditionalSubstitution(condition=gui, false_value='--minimize')
-        stream_argument = _ConditionalSubstitution(condition=stream, true_value='--stream')
+        stream_argument = "",
+        if isinstance(stream, bool):
+            stream_argument = _ConditionalSubstitution(condition=stream, true_value='--stream')
+        else:
+            stream_argument = "--stream="+stream
+
         xvfb_run_prefix = []
 
         if 'WEBOTS_OFFSCREEN' in os.environ:

--- a/webots_ros2_driver/webots_ros2_driver/webots_launcher.py
+++ b/webots_ros2_driver/webots_ros2_driver/webots_launcher.py
@@ -54,7 +54,7 @@ class _ConditionalSubstitution(Substitution):
 
 class WebotsLauncher(ExecuteProcess):
     def __init__(self, output='screen', world=None, gui=True, mode='realtime', stream=False, ros2_supervisor=False,
-                 port="1234", **kwargs):
+                 port='1234', **kwargs):
         if sys.platform == 'win32':
             print('WARNING: Native webots_ros2 compatibility with Windows is deprecated and will be removed soon. Please use a '
                   'WSL (Windows Subsystem for Linux) environment instead.', file=sys.stderr)

--- a/webots_ros2_driver/webots_ros2_driver/webots_launcher.py
+++ b/webots_ros2_driver/webots_ros2_driver/webots_launcher.py
@@ -53,7 +53,8 @@ class _ConditionalSubstitution(Substitution):
 
 
 class WebotsLauncher(ExecuteProcess):
-    def __init__(self, output='screen', world=None, gui=True, mode='realtime', stream=False, ros2_supervisor=False, port="1234", **kwargs):
+    def __init__(self, output='screen', world=None, gui=True, mode='realtime', stream=False, ros2_supervisor=False, 
+                 port="1234", **kwargs):
         if sys.platform == 'win32':
             print('WARNING: Native webots_ros2 compatibility with Windows is deprecated and will be removed soon. Please use a '
                   'WSL (Windows Subsystem for Linux) environment instead.', file=sys.stderr)
@@ -163,12 +164,12 @@ class WebotsLauncher(ExecuteProcess):
         wbproj_path = Path(world_path)
         wbproj_path = wbproj_path.with_suffix('.wbproj')
         wbproj_path = wbproj_path.with_name("."+wbproj_path.name)
-        
+
         if wbproj_path.exists():
             wbproj_copy_path = Path(self.__world_copy.name)
             wbproj_copy_path = wbproj_copy_path.with_suffix('.wbproj')
             wbproj_copy_path = wbproj_copy_path.with_name("."+wbproj_copy_path.name)
-            shutil.copy2(wbproj_path, wbproj_copy_path)    
+            shutil.copy2(wbproj_path, wbproj_copy_path)
 
         # Update relative paths in the world
         with open(self.__world_copy.name, 'r') as file:

--- a/webots_ros2_driver/webots_ros2_driver/webots_launcher.py
+++ b/webots_ros2_driver/webots_ros2_driver/webots_launcher.py
@@ -64,7 +64,7 @@ class WebotsLauncher(ExecuteProcess):
         self.__has_shared_folder = has_shared_folder()
         self.__is_supervisor = ros2_supervisor
         if self.__is_supervisor:
-            self._supervisor = Ros2SupervisorLauncher()
+            self._supervisor = Ros2SupervisorLauncher(port=port)
 
         # Find Webots executable
         if not self.__has_shared_folder:

--- a/webots_ros2_driver/webots_ros2_driver/webots_launcher.py
+++ b/webots_ros2_driver/webots_ros2_driver/webots_launcher.py
@@ -53,7 +53,7 @@ class _ConditionalSubstitution(Substitution):
 
 
 class WebotsLauncher(ExecuteProcess):
-    def __init__(self, output='screen', world=None, gui=True, mode='realtime', stream=False, ros2_supervisor=False, 
+    def __init__(self, output='screen', world=None, gui=True, mode='realtime', stream=False, ros2_supervisor=False,
                  port="1234", **kwargs):
         if sys.platform == 'win32':
             print('WARNING: Native webots_ros2 compatibility with Windows is deprecated and will be removed soon. Please use a '


### PR DESCRIPTION
**Description**
The webots driver launcher do not offer the possibility to set the streaming port. this prevents the use in multi user environments where every user wants to see its own simulation.
Moreover, the launcher only copies the world file and ignores the world project file. Therefore, custom settings (e.g. optional renderings are ignored).

This pull request adds a parameter to webots launcher constructor to set the port. The default parameter setting is set to the default port 1234. Therefore, there should not be any difference for existing setups.
Moreover, the copy of the world project file is added. The execute()-Function searches if a .wbproj file with the same name as the world file exists and then copies it to the location of the temporary world file. When webots starts, it uses the world project file.

**Related Issues**

**Affected Packages**
  - webots_ros2_driver

**Tasks**

