### PR TITLE
Fix ros2_control wheel_separation param for turtlebot3

### DIFF
--- a/webots_ros2_turtlebot/resource/ros2control.yml
+++ b/webots_ros2_turtlebot/resource/ros2control.yml
@@ -13,7 +13,7 @@ diffdrive_controller:
     left_wheel_names: ["left wheel motor"]
     right_wheel_names: ["right wheel motor"]
 
-    wheel_separation: 0.160
+    wheel_separation: 0.178
     wheel_radius: 0.033
 
     use_stamped_vel: false


### PR DESCRIPTION
**Description**
The wheel_separation param in ros2control.yml is incorrect, which would make the odometry not accurate.
While the wheel_separation is set to 1.60, when making the robot to turn and the odometry records 360 degrees, the orientation of the robot in webots is not matched with the odometry.

The initial orientation is shown in the picture below:
![image](https://user-images.githubusercontent.com/22185413/222898320-90734108-b8df-4b95-8e4f-bcc607c6ee9d.png)

After making a 360 degree turn in odometry, the orientation is shown below:
![Screenshot from 2023-03-04 19-05-55](https://user-images.githubusercontent.com/22185413/222898345-fafc92d7-8c8f-45e1-b8b7-93c38d5c08ad.png)

I found that the cause of the problem is related to the wheel_separation parameter. In the "TurtleBot3Burger.proto" file, the position of the left joint is "0 0.08 0.033", and the right joint is "0 -0.08 0.033". So it seems that the separation is 0.16. But that does not take the wheel cylinder into account. The height of the cylinder is 0.018, so the actual wheel separation should be 0.16+2*(0.018/2) = 0.178.

Changing the param would make the odometry works accurately.