### PR TITLE
Fix random Nav2 failure with Fast DDS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       AFTER_INIT: ./scripts/ci_after_init.bash ${ROS_DISTRO} ${ROS_REPO}
-      BEFORE_INIT_EMBED: source scripts/ci_before_init_embed.bash
+      BEFORE_INIT_EMBED: source scripts/ci_before_init_embed.bash ${ROS_DISTRO}
       DOCKER_RUN_OPTS: -v /artifacts:/tmp/artifacts
     steps:
       - uses: actions/checkout@v3

--- a/scripts/ci_after_init.bash
+++ b/scripts/ci_after_init.bash
@@ -31,5 +31,10 @@ if [[ "${ROS_DISTRO}" != "rolling" ]]; then
     apt install -y ros-${ROS_DISTRO}-turtlebot3-cartographer ros-${ROS_DISTRO}-turtlebot3-navigation2 ros-${ROS_DISTRO}-nav2-bringup
 fi
 
+if [[ "${ROS_DISTRO}" == "humble" ]]; then
+    apt install -y ros-${ROS_DISTRO}-rmw-cyclonedds-cpp
+    export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+fi
+
 # Setup Qt plugins for RViz (can be used once RViz does not randomly crash anymore in GitHub CI).
 #export QT_PLUGIN_PATH=/usr/lib/x86_64-linux-gnu/qt5/plugins

--- a/scripts/ci_after_init.bash
+++ b/scripts/ci_after_init.bash
@@ -33,7 +33,6 @@ fi
 
 if [[ "${ROS_DISTRO}" == "humble" ]]; then
     apt install -y ros-${ROS_DISTRO}-rmw-cyclonedds-cpp
-    export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
 fi
 
 # Setup Qt plugins for RViz (can be used once RViz does not randomly crash anymore in GitHub CI).

--- a/scripts/ci_after_init.bash
+++ b/scripts/ci_after_init.bash
@@ -31,6 +31,8 @@ if [[ "${ROS_DISTRO}" != "rolling" ]]; then
     apt install -y ros-${ROS_DISTRO}-turtlebot3-cartographer ros-${ROS_DISTRO}-turtlebot3-navigation2 ros-${ROS_DISTRO}-nav2-bringup
 fi
 
+# TODO: Revert once the https://github.com/ros-planning/navigation2/issues/3033 issue is fixed.
+# Fast-DDS is not working properly with the Nav2 package on Humble. Using Cyclone DDS instead.
 if [[ "${ROS_DISTRO}" == "humble" ]]; then
     apt install -y ros-${ROS_DISTRO}-rmw-cyclonedds-cpp
 fi

--- a/scripts/ci_before_init_embed.bash
+++ b/scripts/ci_before_init_embed.bash
@@ -4,3 +4,4 @@ export WEBOTS_RELEASE_VERSION=2023a-rev1
 export WEBOTS_OFFSCREEN=1
 export CI=1
 export DEBIAN_FRONTEND=noninteractive
+export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp

--- a/scripts/ci_before_init_embed.bash
+++ b/scripts/ci_before_init_embed.bash
@@ -6,6 +6,9 @@ export WEBOTS_RELEASE_VERSION=2023a-rev1
 export WEBOTS_OFFSCREEN=1
 export CI=1
 export DEBIAN_FRONTEND=noninteractive
+
+# TODO: Revert once the https://github.com/ros-planning/navigation2/issues/3033 issue is fixed.
+# Fast-DDS is not working properly with the Nav2 package on Humble. Using Cyclone DDS instead.
 if [[ "${ROS_DISTRO}" == "humble" ]]; then
     export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
 fi

--- a/scripts/ci_before_init_embed.bash
+++ b/scripts/ci_before_init_embed.bash
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 
+ROS_DISTRO=$1
+
 export WEBOTS_RELEASE_VERSION=2023a-rev1
 export WEBOTS_OFFSCREEN=1
 export CI=1
 export DEBIAN_FRONTEND=noninteractive
-export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+if [[ "${ROS_DISTRO}" == "humble" ]]; then
+    export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+fi


### PR DESCRIPTION
Nav2 random failures in the TIAGo tests are due to issues with the default Fast DDS on Humble. See https://github.com/ros-planning/navigation2/issues/3033#issuecomment-1457854463 comment and issue.

We switch the DDS to Cyclone to fix the problem.