### PR TITLE
Cleaner ros2_control parameters

### DIFF
--- a/webots_ros2_tiago/resource/ros2_control.yml
+++ b/webots_ros2_tiago/resource/ros2_control.yml
@@ -13,9 +13,11 @@ diffdrive_controller:
     left_wheel_names: ["wheel_left_joint"]
     right_wheel_names: ["wheel_right_joint"]
 
-    # Values don't correspond exactly to the ones in the robot URDF but result in more accurate odometry
-    wheel_separation: 0.44
-    wheel_radius: 0.098
+    wheel_separation: 0.404
+    wheel_radius: 0.0985
+
+    # The real separation between wheels is not resulting in a perfect odometry
+    wheel_separation_multiplier: 1.089
 
     use_stamped_vel: false
     base_frame_id: "base_link"

--- a/webots_ros2_turtlebot/resource/ros2control.yml
+++ b/webots_ros2_turtlebot/resource/ros2control.yml
@@ -13,8 +13,11 @@ diffdrive_controller:
     left_wheel_names: ["left wheel motor"]
     right_wheel_names: ["right wheel motor"]
 
-    wheel_separation: 0.178
+    wheel_separation: 0.16
     wheel_radius: 0.033
+
+    # The real separation between wheels is not resulting in a perfect odometry
+    wheel_separation_multiplier: 1.112
 
     use_stamped_vel: false
     base_frame_id: "base_link"


### PR DESCRIPTION
Based on https://github.com/cyberbotics/webots_ros2/pull/676#discussion_r1140120581, it is cleaner to define the correct parameters for wheel separation and wheel radius. The multiplier parameter allows to adjust the parameter at runtime to obtain optimal odometry.