### PR TITLE
Fix CI tests

### DIFF
--- a/scripts/ci_after_init.bash
+++ b/scripts/ci_after_init.bash
@@ -30,8 +30,8 @@ fi
 if [[ "${ROS_DISTRO}" != "rolling" ]]; then
     apt install -y ros-${ROS_DISTRO}-nav2-bringup git
 
-    mkdir -p /root/upstream_ws/src
-    git clone -b ros2 https://github.com/ROBOTIS-GIT/turtlebot3.git /root/upstream_ws/src
+    mkdir -p /root/turtlebot_ws/src
+    git clone -b ros2 https://github.com/ROBOTIS-GIT/turtlebot3.git /root/turtlebot_ws/src
 fi
 
 # TODO: Revert once the https://github.com/ros-planning/navigation2/issues/3033 issue is fixed.

--- a/scripts/ci_after_init.bash
+++ b/scripts/ci_after_init.bash
@@ -28,7 +28,8 @@ fi
 
 # The following packages are not available in the ROS 2 Rolling distribution. Therefore, we cannot include them in the package.xml, but we have to install them manually here.
 if [[ "${ROS_DISTRO}" != "rolling" ]]; then
-    apt install -y ros-${ROS_DISTRO}-turtlebot3-cartographer ros-${ROS_DISTRO}-turtlebot3-navigation2 ros-${ROS_DISTRO}-nav2-bringup
+    apt install -y ros-${ROS_DISTRO}-nav2-bringup
+    git clone -b ${ROS_DISTRO}-devel https://github.com/ROBOTIS-GIT/turtlebot3.git /root/target_ws/src
 fi
 
 # TODO: Revert once the https://github.com/ros-planning/navigation2/issues/3033 issue is fixed.

--- a/scripts/ci_after_init.bash
+++ b/scripts/ci_after_init.bash
@@ -29,11 +29,10 @@ fi
 # The following packages are not available in the ROS 2 Rolling distribution. Therefore, we cannot include them in the package.xml, but we have to install them manually here.
 if [[ "${ROS_DISTRO}" != "rolling" ]]; then
     apt install -y ros-${ROS_DISTRO}-nav2-bringup git
-fi
 
-if [[ "${ROS_DISTRO}" != "rolling" ]]; then
     mkdir -p /root/target_ws2/src
     git clone -b ${ROS_DISTRO}-devel https://github.com/ROBOTIS-GIT/turtlebot3.git /root/target_ws2/src
+    source /opt/ros/${ROS_DISTRO}/setup.bash
     rosdep install -y -r -q --from-paths /root/target_ws2/src --ignore-src --rosdistro ${ROS_DISTRO}
     colcon build
 fi

--- a/scripts/ci_after_init.bash
+++ b/scripts/ci_after_init.bash
@@ -29,7 +29,13 @@ fi
 # The following packages are not available in the ROS 2 Rolling distribution. Therefore, we cannot include them in the package.xml, but we have to install them manually here.
 if [[ "${ROS_DISTRO}" != "rolling" ]]; then
     apt install -y ros-${ROS_DISTRO}-nav2-bringup git
-    git clone -b ${ROS_DISTRO}-devel https://github.com/ROBOTIS-GIT/turtlebot3.git /root/target_ws/src
+fi
+
+if [[ "${ROS_DISTRO}" != "rolling" ]]; then
+    mkdir -p /root/target_ws2/src
+    git clone -b ${ROS_DISTRO}-devel https://github.com/ROBOTIS-GIT/turtlebot3.git /root/target_ws2/src
+    rosdep install -y -r -q --from-paths /root/target_ws2/src --ignore-src --rosdistro ${ROS_DISTRO}
+    colcon build
 fi
 
 # TODO: Revert once the https://github.com/ros-planning/navigation2/issues/3033 issue is fixed.

--- a/scripts/ci_after_init.bash
+++ b/scripts/ci_after_init.bash
@@ -31,7 +31,7 @@ if [[ "${ROS_DISTRO}" != "rolling" ]]; then
     apt install -y ros-${ROS_DISTRO}-nav2-bringup git
 
     mkdir -p /root/turtlebot_ws/src
-    git clone -b ros2 https://github.com/ROBOTIS-GIT/turtlebot3.git /root/turtlebot_ws/src
+    git clone -b ${ROS_DISTRO}-devel https://github.com/cyberbotics/turtlebot3.git /root/turtlebot_ws/src
 fi
 
 # TODO: Revert once the https://github.com/ros-planning/navigation2/issues/3033 issue is fixed.

--- a/scripts/ci_after_init.bash
+++ b/scripts/ci_after_init.bash
@@ -14,7 +14,7 @@ NIGHTLY_DATE=`date --date="${LAST_NIGHTLY_DAY_OLD} day ago" +"%-d_%-m_%Y"`
 WEBOTS_NIGHTLY_VERSION="nightly_${NIGHTLY_DATE}"
 
 apt update
-apt install -y wget dialog apt-utils psmisc lsb-release
+apt install -y wget dialog apt-utils psmisc lsb-release git
 wget https://github.com/cyberbotics/webots/releases/download/${WEBOTS_NIGHTLY_VERSION}/webots_${WEBOTS_RELEASE_VERSION}_amd64.deb -O /tmp/webots.deb
 apt install -y /tmp/webots.deb xvfb
 
@@ -28,8 +28,9 @@ fi
 
 # The following packages are not available in the ROS 2 Rolling distribution. Therefore, we cannot include them in the package.xml, but we have to install them manually here.
 if [[ "${ROS_DISTRO}" != "rolling" ]]; then
-    apt install -y ros-${ROS_DISTRO}-nav2-bringup git
+    apt install -y ros-${ROS_DISTRO}-nav2-bringup
 
+    # Turtlebot3 must be installed from sources to make RViz optional
     mkdir -p /root/turtlebot_ws/src
     git clone -b ${ROS_DISTRO}-devel https://github.com/cyberbotics/turtlebot3.git /root/turtlebot_ws/src
 fi

--- a/scripts/ci_after_init.bash
+++ b/scripts/ci_after_init.bash
@@ -32,9 +32,6 @@ if [[ "${ROS_DISTRO}" != "rolling" ]]; then
 
     mkdir -p /root/target_ws2/src
     git clone -b ${ROS_DISTRO}-devel https://github.com/ROBOTIS-GIT/turtlebot3.git /root/target_ws2/src
-    source /opt/ros/${ROS_DISTRO}/setup.bash
-    rosdep install -y -r -q --from-paths /root/target_ws2/src --ignore-src --rosdistro ${ROS_DISTRO}
-    colcon build
 fi
 
 # TODO: Revert once the https://github.com/ros-planning/navigation2/issues/3033 issue is fixed.

--- a/scripts/ci_after_init.bash
+++ b/scripts/ci_after_init.bash
@@ -28,7 +28,7 @@ fi
 
 # The following packages are not available in the ROS 2 Rolling distribution. Therefore, we cannot include them in the package.xml, but we have to install them manually here.
 if [[ "${ROS_DISTRO}" != "rolling" ]]; then
-    apt install -y ros-${ROS_DISTRO}-nav2-bringup
+    apt install -y ros-${ROS_DISTRO}-nav2-bringup git
     git clone -b ${ROS_DISTRO}-devel https://github.com/ROBOTIS-GIT/turtlebot3.git /root/target_ws/src
 fi
 

--- a/scripts/ci_after_init.bash
+++ b/scripts/ci_after_init.bash
@@ -30,8 +30,8 @@ fi
 if [[ "${ROS_DISTRO}" != "rolling" ]]; then
     apt install -y ros-${ROS_DISTRO}-nav2-bringup git
 
-    mkdir -p /root/target_ws2/src
-    git clone -b ${ROS_DISTRO}-devel https://github.com/ROBOTIS-GIT/turtlebot3.git /root/target_ws2/src
+    mkdir -p /root/upstream_ws/src
+    git clone -b ros2 https://github.com/ROBOTIS-GIT/turtlebot3.git /root/upstream_ws/src
 fi
 
 # TODO: Revert once the https://github.com/ros-planning/navigation2/issues/3033 issue is fixed.

--- a/scripts/ci_before_init_embed.bash
+++ b/scripts/ci_before_init_embed.bash
@@ -6,6 +6,7 @@ export WEBOTS_RELEASE_VERSION=2023a-rev1
 export WEBOTS_OFFSCREEN=1
 export CI=1
 export DEBIAN_FRONTEND=noninteractive
+# The upstream workspace allows to install packages from sources for the tests (Turtlebot3 here)
 if [[ "${ROS_DISTRO}" != "rolling" ]]; then
     export UPSTREAM_WORKSPACE=/root/turtlebot_ws/
 fi

--- a/scripts/ci_before_init_embed.bash
+++ b/scripts/ci_before_init_embed.bash
@@ -6,7 +6,7 @@ export WEBOTS_RELEASE_VERSION=2023a-rev1
 export WEBOTS_OFFSCREEN=1
 export CI=1
 export DEBIAN_FRONTEND=noninteractive
-export UNDERLAY=/root/target_ws2/install
+export UPSTREAM_WORKSPACE=/root/target_ws2/
 
 # TODO: Revert once the https://github.com/ros-planning/navigation2/issues/3033 issue is fixed.
 # Fast-DDS is not working properly with the Nav2 package on Humble. Using Cyclone DDS instead.

--- a/scripts/ci_before_init_embed.bash
+++ b/scripts/ci_before_init_embed.bash
@@ -6,6 +6,7 @@ export WEBOTS_RELEASE_VERSION=2023a-rev1
 export WEBOTS_OFFSCREEN=1
 export CI=1
 export DEBIAN_FRONTEND=noninteractive
+export UNDERLAY=/root/target_ws/install
 
 # TODO: Revert once the https://github.com/ros-planning/navigation2/issues/3033 issue is fixed.
 # Fast-DDS is not working properly with the Nav2 package on Humble. Using Cyclone DDS instead.

--- a/scripts/ci_before_init_embed.bash
+++ b/scripts/ci_before_init_embed.bash
@@ -7,7 +7,7 @@ export WEBOTS_OFFSCREEN=1
 export CI=1
 export DEBIAN_FRONTEND=noninteractive
 if [[ "${ROS_DISTRO}" != "rolling" ]]; then
-    export UPSTREAM_WORKSPACE=/root/upstream_ws/
+    export UPSTREAM_WORKSPACE=/root/turtlebot_ws/
 fi
 
 

--- a/scripts/ci_before_init_embed.bash
+++ b/scripts/ci_before_init_embed.bash
@@ -6,7 +6,10 @@ export WEBOTS_RELEASE_VERSION=2023a-rev1
 export WEBOTS_OFFSCREEN=1
 export CI=1
 export DEBIAN_FRONTEND=noninteractive
-export UPSTREAM_WORKSPACE=/root/target_ws2/
+if [[ "${ROS_DISTRO}" != "rolling" ]]; then
+    export UPSTREAM_WORKSPACE=/root/upstream_ws/
+fi
+
 
 # TODO: Revert once the https://github.com/ros-planning/navigation2/issues/3033 issue is fixed.
 # Fast-DDS is not working properly with the Nav2 package on Humble. Using Cyclone DDS instead.

--- a/scripts/ci_before_init_embed.bash
+++ b/scripts/ci_before_init_embed.bash
@@ -6,7 +6,7 @@ export WEBOTS_RELEASE_VERSION=2023a-rev1
 export WEBOTS_OFFSCREEN=1
 export CI=1
 export DEBIAN_FRONTEND=noninteractive
-export UNDERLAY=/root/target_ws/install
+export UNDERLAY=/root/target_ws2/install
 
 # TODO: Revert once the https://github.com/ros-planning/navigation2/issues/3033 issue is fixed.
 # Fast-DDS is not working properly with the Nav2 package on Humble. Using Cyclone DDS instead.

--- a/webots_ros2_turtlebot/launch/robot_launch.py
+++ b/webots_ros2_turtlebot/launch/robot_launch.py
@@ -98,6 +98,10 @@ def get_ros2_nodes(*args):
     )
 
     nav_nodes = []
+    if 'CI' in os.environ and os.environ['CI'] == '1':
+        use_rviz = [('use_rviz', False)]
+    else:
+        use_rviz = []
     # Navigation
     os.environ['TURTLEBOT3_MODEL'] = 'burger'
     if 'turtlebot3_navigation2' in get_packages_with_prefixes():
@@ -108,7 +112,7 @@ def get_ros2_nodes(*args):
                 ('map', nav2_map),
                 ('params_file', nav2_params),
                 ('use_sim_time', use_sim_time),
-            ],
+            ] + use_rviz,
             condition=launch.conditions.IfCondition(use_nav))
         nav_nodes.append(turtlebot_navigation)
 
@@ -119,7 +123,7 @@ def get_ros2_nodes(*args):
                 get_package_share_directory('turtlebot3_cartographer'), 'launch', 'cartographer.launch.py')),
             launch_arguments=[
                 ('use_sim_time', use_sim_time),
-            ],
+            ] + use_rviz,
             condition=launch.conditions.IfCondition(use_slam))
         nav_nodes.append(turtlebot_slam)
 

--- a/webots_ros2_turtlebot/launch/robot_launch.py
+++ b/webots_ros2_turtlebot/launch/robot_launch.py
@@ -98,10 +98,6 @@ def get_ros2_nodes(*args):
     )
 
     nav_nodes = []
-    if 'CI' in os.environ and os.environ['CI'] == '1':
-        use_rviz = [('use_rviz', False)]
-    else:
-        use_rviz = []
     # Navigation
     os.environ['TURTLEBOT3_MODEL'] = 'burger'
     if 'turtlebot3_navigation2' in get_packages_with_prefixes():
@@ -112,7 +108,7 @@ def get_ros2_nodes(*args):
                 ('map', nav2_map),
                 ('params_file', nav2_params),
                 ('use_sim_time', use_sim_time),
-            ] + use_rviz,
+            ],
             condition=launch.conditions.IfCondition(use_nav))
         nav_nodes.append(turtlebot_navigation)
 
@@ -123,7 +119,7 @@ def get_ros2_nodes(*args):
                 get_package_share_directory('turtlebot3_cartographer'), 'launch', 'cartographer.launch.py')),
             launch_arguments=[
                 ('use_sim_time', use_sim_time),
-            ] + use_rviz,
+            ],
             condition=launch.conditions.IfCondition(use_slam))
         nav_nodes.append(turtlebot_slam)
 


### PR DESCRIPTION
RViz must be disabled in the CI, to avoid random display failures. The visualization tool is not necessary in the CI.

The `turtlebot3` has no option to disable RViz. The repository is forked and modified to make it optional. The package can be installed from sources in the ROS industrial framework by using the upstream workspace.