### PR TITLE
Cleanup e-puck tools to run RViz alone

### DIFF
--- a/webots_ros2/CHANGELOG.rst
+++ b/webots_ros2/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package webots_ros2
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2023.0.4 (2023-XX-XX)
+------------------
+* Fixed ability to launch RViz without other tools in e-puck example.
+
 2023.0.3 (2023-04-12)
 ------------------
 * Fixed the calibration of the TIAGo.

--- a/webots_ros2_epuck/CHANGELOG.rst
+++ b/webots_ros2_epuck/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package webots_ros2_epuck
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2023.0.4 (2023-XX-XX)
+------------------
+* Fixed ability to launch RViz without other tools.
+
 2023.0.3 (2023-04-12)
 ------------------
 * Refactored launch files.

--- a/webots_ros2_epuck/launch/robot_launch.py
+++ b/webots_ros2_epuck/launch/robot_launch.py
@@ -110,36 +110,20 @@ def get_ros2_nodes(*args):
         arguments=['0', '0', '0', '0', '0', '0', 'base_link', 'base_footprint'],
     )
 
-    tool_nodes = []
-    # Navigation
-    nav_tools = IncludeLaunchDescription(
+    # Tools
+    tool_nodes = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             os.path.join(package_dir, 'launch', 'robot_tools_launch.py')
         ),
         launch_arguments={
+            'fill_map': fill_map,
+            'mapper': use_mapper,
+            'map': map_filename,
             'nav': use_nav,
             'rviz': use_rviz,
             'use_sim_time': use_sim_time,
-            'map': map_filename,
         }.items(),
-        condition=launch.conditions.IfCondition(use_nav)
     )
-    tool_nodes.append(nav_tools)
-
-    # Mapping
-    mapper_tools = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource(
-            os.path.join(package_dir, 'launch', 'robot_tools_launch.py')
-        ),
-        launch_arguments={
-            'rviz': use_rviz,
-            'mapper': use_mapper,
-            'use_sim_time': use_sim_time,
-            'fill_map': fill_map,
-        }.items(),
-        condition=launch.conditions.IfCondition(use_mapper)
-    )
-    tool_nodes.append(mapper_tools)
 
     # Wait for the simulation to be ready to start the tools
     tools_handler = launch.actions.RegisterEventHandler(


### PR DESCRIPTION
With the previous e-puck fix (#694), it was not possible to launch RViz from the main launch file without the Navigation or Mapping tool. RViz can still be used alone for odometry visualization for example. This PR cleans up the way tools are launched.