### PR TITLE
Calculate vertical fov according to https://www.cyberbotics.com/doc/r…

### DIFF
--- a/webots_ros2/CHANGELOG.rst
+++ b/webots_ros2/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog for package webots_ros2
 
 2023.0.4 (2023-XX-XX)
 ------------------
+* Fixed vertical field of view in ros2 rangefinder plugin.
 * Added support for painted point clouds
 * Fixed ability to launch RViz without other tools in e-puck example.
 * Fixed command line arguments in importer tools.

--- a/webots_ros2/CHANGELOG.rst
+++ b/webots_ros2/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog for package webots_ros2
 
 2023.0.4 (2023-XX-XX)
 ------------------
-* Fixed vertical field of view in ros2 rangefinder plugin.
+* Fixed vertical field of view in static RangeFinder plugin.
 * Added support for painted point clouds
 * Fixed ability to launch RViz without other tools in e-puck example.
 * Fixed command line arguments in importer tools.

--- a/webots_ros2_driver/CHANGELOG.rst
+++ b/webots_ros2_driver/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog for package webots_ros2_driver
 
 2023.0.4 (2023-XX-XX)
 ------------------
-* Fixed vertical field of view in ros2 rangefinder plugin.
+* Fixed vertical field of view in static RangeFinder plugin.
 * Added support for painted point clouds
 
 2023.0.3 (2023-04-12)

--- a/webots_ros2_driver/CHANGELOG.rst
+++ b/webots_ros2_driver/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog for package webots_ros2_driver
 
 2023.0.4 (2023-XX-XX)
 ------------------
+* Fixed vertical field of view in ros2 rangefinder plugin.
 * Added support for painted point clouds
 
 2023.0.3 (2023-04-12)

--- a/webots_ros2_driver/src/plugins/static/Ros2RangeFinder.cpp
+++ b/webots_ros2_driver/src/plugins/static/Ros2RangeFinder.cpp
@@ -48,8 +48,10 @@ namespace webots_ros2_driver {
     mCameraInfoMessage.height = height;
     mCameraInfoMessage.width = width;
     mCameraInfoMessage.distortion_model = "plumb_bob";
-    const double focalLengthX = 0.5 * width * (1 / tan(0.5 * wb_range_finder_get_fov(mRangeFinder)));
-    const double focalLengthY = 0.5 * height * (1 / tan(0.5 * wb_range_finder_get_fov(mRangeFinder)));
+    const double horizontalFov = wb_range_finder_get_fov(mRangeFinder);
+    const double verticalFov = 2 * atan(tan(horizontalFov * 0.5) * (double(height) / width));
+    const double focalLengthX = 0.5 * width * (1 / tan(0.5 * horizontalFov));
+    const double focalLengthY = 0.5 * height * (1 / tan(0.5 * verticalFov));
     mCameraInfoMessage.d = {0.0, 0.0, 0.0, 0.0, 0.0};
     mCameraInfoMessage.r = {1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0};
     mCameraInfoMessage.k = {focalLengthX, 0.0, (double)width / 2, 0.0, focalLengthY, (double)height / 2, 0.0, 0.0, 1.0};


### PR DESCRIPTION
**Description**
 `Ros2RangeFinder::init` uses the horizontal field of view to determine the vertical focal length. 
According to https://www.cyberbotics.com/doc/reference/rangefinder the vertical FOV (and thus focal length) should be derived from 
`vertical FOV = 2 * atan(tan(fieldOfView * 0.5) * (height / width))`
This PR implements that change.

PS: Thanks for providing this package! It makes working with sim in ROS2 a easy.

**Affected Packages**
List of affected packages:
  - webots_ros2_driver

**Tasks**
Add the list of tasks of this PR.
  - [x] Implement fix

**Additional context**

Before the fix, point clouds are skewed and do not match the environment.
![before](https://user-images.githubusercontent.com/18635834/235578486-5ec52cb3-e523-4795-b98f-df44e2bf710e.png)

After the fix, point clouds match the environment.
![after](https://user-images.githubusercontent.com/18635834/235578467-db69076c-0f0c-4b8f-b66d-1233a397a04a.png)
