### PR TITLE
webots_ros2_driver native MacOS support

### DIFF
--- a/webots_ros2_driver/CMakeLists.txt
+++ b/webots_ros2_driver/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.15)
 project(webots_ros2_driver)
 
 # Check which ROS distribution is used, ros2control depends of that

--- a/webots_ros2_driver/CMakeLists.txt
+++ b/webots_ros2_driver/CMakeLists.txt
@@ -40,13 +40,17 @@ else()
   find_package(PythonLibs 3.10 EXACT REQUIRED)
 endif()
 
+if(APPLE)
+  set(MAKE_VARS "NO_FAT_BINARY=1")
+endif()
+
 add_custom_target(compile-lib-controller ALL
-  COMMAND ${CMAKE_COMMAND} -E env "WEBOTS_HOME=${CMAKE_CURRENT_SOURCE_DIR}/webots" make release -f Makefile > /dev/null 2>&1
+  COMMAND ${CMAKE_COMMAND} -E env "WEBOTS_HOME=${CMAKE_CURRENT_SOURCE_DIR}/webots" make -j1 release -f Makefile ${MAKE_VARS}
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/webots/src/controller
 )
 
 add_custom_target(compile-lib-vehicle ALL
-  COMMAND ${CMAKE_COMMAND} -E env "WEBOTS_HOME=${CMAKE_CURRENT_SOURCE_DIR}/webots" make release -f Makefile > /dev/null 2>&1
+  COMMAND ${CMAKE_COMMAND} -E env "WEBOTS_HOME=${CMAKE_CURRENT_SOURCE_DIR}/webots" make -j1 release -f Makefile ${MAKE_VARS}
   DEPENDS compile-lib-controller
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/webots/projects/default/libraries/vehicle
 )

--- a/webots_ros2_driver/CMakeLists.txt
+++ b/webots_ros2_driver/CMakeLists.txt
@@ -80,8 +80,14 @@ ament_python_install_package(vehicle
 ament_python_install_package(${PROJECT_NAME}
   PACKAGE_DIR ${PROJECT_NAME})
 
-# Driver
-set(CMAKE_INSTALL_RPATH "$ORIGIN/../controller")
+if(UNIX AND NOT APPLE)
+  set(DYN_LOADER_PREFIX "$ORIGIN")
+elseif(APPLE)
+  set(DYN_LOADER_PREFIX "@executable_path")
+endif()
+
+set(CMAKE_INSTALL_RPATH "${DYN_LOADER_PREFIX}/../controller")
+
 add_executable(driver
   src/Driver.cpp
   src/WebotsNode.cpp
@@ -129,7 +135,7 @@ install(TARGETS driver
 )
 
 # Dynamic IMU
-set(CMAKE_INSTALL_RPATH "$ORIGIN/controller")
+set(CMAKE_INSTALL_RPATH "${DYN_LOADER_PREFIX}/controller")
 add_library(
   ${PROJECT_NAME}_imu
   SHARED
@@ -157,7 +163,7 @@ install(TARGETS ${PROJECT_NAME}_imu
 )
 
 # Dynamic RGBD
-set(CMAKE_INSTALL_RPATH "$ORIGIN/controller")
+set(CMAKE_INSTALL_RPATH "${DYN_LOADER_PREFIX}/controller")
 add_library(
   ${PROJECT_NAME}_rgbd
   SHARED

--- a/webots_ros2_driver/webots/lib/controller/python/controller/wb.py
+++ b/webots_ros2_driver/webots/lib/controller/python/controller/wb.py
@@ -21,7 +21,7 @@ if sys.platform == 'linux' or sys.platform == 'linux2':
 elif sys.platform == 'win32':
     path = os.path.join('lib', 'controller', 'Controller.dll')
 elif sys.platform == 'darwin':
-    path = os.path.join('Contents', 'lib', 'controller', 'libController.dylib')
+    path = os.path.join('lib', 'controller', 'libController.dylib')
 
 wb = ctypes.cdll.LoadLibrary(os.path.join(os.environ['WEBOTS_HOME'], path))
 

--- a/webots_ros2_driver/webots/lib/controller/python/vehicle/driver.py
+++ b/webots_ros2_driver/webots/lib/controller/python/vehicle/driver.py
@@ -43,7 +43,7 @@ class Driver(Supervisor):
             car = 'car.dll'
             driver = 'driver.dll'
         elif sys.platform == 'darwin':
-            path = os.path.join('Contents', 'MacOS', 'lib', 'controller')
+            path = os.path.join('lib', 'controller')
             car = 'libcar.dylib'
             driver = 'libdriver.dylib'
         ctypes.cdll.LoadLibrary(os.path.join(os.environ['WEBOTS_HOME'], path, car))

--- a/webots_ros2_driver/webots/projects/default/libraries/vehicle/java/Makefile
+++ b/webots_ros2_driver/webots/projects/default/libraries/vehicle/java/Makefile
@@ -106,7 +106,7 @@ $(WRAPPER_OBJECT_X86_64): $(WRAPPER)
 	@$(CXX) -target x86_64-apple-macos11 $(CFLAGS1) -bundle $(WRAPPER_OBJECT_X86_64) $(LIB) -o lib$(MODULE_NAME)-x86_64.jnilib
 	@mkdir -p $(WEBOTS_CONTROLLER_LIB_PATH)/java
 	@lipo -create -output "$@" lib$(MODULE_NAME)-arm64.jnilib lib$(MODULE_NAME)-x86_64.jnilib
-	@codesign -s - "$@"
+	# @codesign -s - "$@"
 endif
 
 clean:

--- a/webots_ros2_driver/webots/resources/Makefile.include
+++ b/webots_ros2_driver/webots/resources/Makefile.include
@@ -441,6 +441,8 @@ ifdef USE_ODE
  endif
  ifeq ($(OSTYPE),darwin)
   DYNAMIC_LINK_FLAGS += -flat_namespace -undefined suppress
+ endif
+ ifdef BUILD_MACOS_BUNDLE
   DYNAMIC_LIBRARIES += "$(WEBOTS_HOME)/Contents/Resources/projects/plugins/physics/physics.a"
   INCLUDE += -I"$(WEBOTS_HOME)/Contents/include/ode" -I"$(WEBOTS_HOME)/Contents/include"
  else

--- a/webots_ros2_driver/webots/resources/Makefile.include
+++ b/webots_ros2_driver/webots/resources/Makefile.include
@@ -321,6 +321,7 @@ endif
 
 ifeq ($(OSTYPE),darwin)
 ifdef NO_FAT_BINARY
+ PROCESSOR := $(shell uname -m)
  WBCFLAGS += -target $(PROCESSOR)-apple-macos11
  DYNAMIC_LINK_FLAGS += -target $(PROCESSOR)-apple-macos11
 endif
@@ -337,14 +338,14 @@ ifdef USE_CXX
  ifndef EXCLUDE_CONTROLLERS
   DYNAMIC_LIBRARIES += -L"$(WEBOTS_CONTROLLER_LIB_PATH)" -lController
   ifdef USE_C_API
-   ifeq ($(OSTYPE),darwin)
+   ifdef BUILD_MACOS_BUNDLE
     INCLUDE += -I"$(WEBOTS_HOME)/Contents/include/controller/c"
    else
     INCLUDE += -I"$(WEBOTS_HOME)/include/controller/c"
    endif
   else
    DYNAMIC_LIBRARIES += -lCppController
-   ifeq ($(OSTYPE),darwin)
+   ifdef BUILD_MACOS_BUNDLE
     INCLUDE += -I"$(WEBOTS_HOME)/Contents/include/controller/cpp"
    else
     INCLUDE += -I"$(WEBOTS_HOME)/include/controller/cpp"
@@ -365,7 +366,7 @@ else
   LINKER = $(CC)
  endif
  ifndef EXCLUDE_CONTROLLERS
-  ifeq ($(OSTYPE),darwin)
+  ifdef BUILD_MACOS_BUNDLE
    INCLUDE += -I"$(WEBOTS_HOME)/Contents/include/controller/c"
   else
    INCLUDE += -I"$(WEBOTS_HOME)/include/controller/c"
@@ -405,7 +406,11 @@ endif
 
 ifeq ($(OSTYPE),darwin)
  ifdef WEBOTS_LIBRARY
-  INSTALL_NAME ?= @rpath/Contents/lib/controller/$(MAIN_TARGET)
+  ifdef BUILD_MACOS_BUNDLE
+    INSTALL_NAME ?= @rpath/Contents/lib/controller/$(MAIN_TARGET)
+  else
+    INSTALL_NAME ?= @rpath/$(MAIN_TARGET)
+  endif
   LFLAGS += -Xlinker -rpath -Xlinker @loader_path/.. -install_name $(INSTALL_NAME)
  else
   CALLING_MAKEFILE_DIR := $(shell dirname "$(realpath $(firstword $(MAKEFILE_LIST)))")

--- a/webots_ros2_driver/webots/resources/Makefile.os.include
+++ b/webots_ros2_driver/webots/resources/Makefile.os.include
@@ -100,11 +100,14 @@ else
  LIB_PREFIX = lib
  ifeq ($(OSTYPE),linux)
   SHARED_LIB_EXTENSION = .so
-  WEBOTS_LIB_PATH=$(WEBOTS_HOME)/lib/webots
-  WEBOTS_CONTROLLER_LIB_PATH=$(WEBOTS_HOME)/lib/controller
  else # macOS
   SHARED_LIB_EXTENSION = .dylib
+ endif
+ ifdef BUILD_MACOS_BUNDLE
   WEBOTS_LIB_PATH=$(WEBOTS_HOME)/Contents/lib/webots
   WEBOTS_CONTROLLER_LIB_PATH=$(WEBOTS_HOME)/Contents/lib/controller
+ else
+  WEBOTS_LIB_PATH=$(WEBOTS_HOME)/lib/webots
+  WEBOTS_CONTROLLER_LIB_PATH=$(WEBOTS_HOME)/lib/controller
  endif
 endif

--- a/webots_ros2_driver/webots/src/controller/c/Makefile
+++ b/webots_ros2_driver/webots/src/controller/c/Makefile
@@ -38,7 +38,12 @@ WEBOTS_DEPENDENCY_PATH ?= $(WEBOTS_HOME_PATH)/dependencies
 ifeq ($(OSTYPE),darwin)
 CFLAGS      = -mmacosx-version-min=$(MACOSX_MIN_SDK_VERSION) -fpascal-strings -Wno-deprecated-declarations -I/Developer/Headers/FlatCarbon -Wall -fno-common
 INCLUDE     = -I$(WEBOTS_HOME_PATH)/include/controller/c -I$(WEBOTS_HOME_PATH)/include
-LD_FLAGS    = -mmacosx-version-min=$(MACOSX_MIN_SDK_VERSION) -dynamiclib -install_name @rpath/Contents/lib/controller/libController.dylib -compatibility_version 1.0 -current_version 1.0.0
+LD_FLAGS    = -mmacosx-version-min=$(MACOSX_MIN_SDK_VERSION) -dynamiclib -compatibility_version 1.0 -current_version 1.0.0
+ifdef BUILD_MACOS_BUNDLE
+LD_FLAGS += -install_name @rpath/Contents/lib/controller/libController.dylib
+else
+LD_FLAGS += -install_name @rpath/libController.dylib
+endif
 SHARED_LIBS = -lz
 TARGET      = $(WEBOTS_CONTROLLER_LIB_PATH)/libController.dylib
 CC          = gcc
@@ -137,15 +142,17 @@ endif
 
 endif
 
-ifeq ($(OSTYPE),darwin)
-X86_64_OBJECTS = $(addprefix $(OBJDIR)/x86_64/, $(OBJECTS))
+
+
+ifdef FAT_BINARY
 ARM64_OBJECTS = $(addprefix $(OBJDIR)/arm64/, $(OBJECTS))
+X86_64_OBJECTS = $(addprefix $(OBJDIR)/x86_64/, $(OBJECTS))
 
 $(TARGET): $(OBJDIR)/x86_64/libController.dylib $(OBJDIR)/arm64/libController.dylib
 	@echo "# creating fat binary: $$"\(WEBOTS_HOME\)/lib/controller/libController.dylib
 	@lipo -create -output $(TARGET) $(OBJDIR)/x86_64/libController.dylib $(OBJDIR)/arm64/libController.dylib
 	@chmod a-x $@
-	@codesign -s - $@
+	# @codesign -s - $@
 
 $(OBJDIR)/x86_64/libController.dylib: $(X86_64_OBJECTS)
 	@echo "# linking "$@" (x86_64)"
@@ -157,9 +164,7 @@ $(OBJDIR)/arm64/libController.dylib: $(ARM64_OBJECTS)
 	@$(CC) $(LD_FLAGS) -target arm64-apple-macos11 -o $@ $(ARM64_OBJECTS) $(SHARED_LIBS)
 	@chmod a-x $@
 
-endif
-
-ifeq ($(OSTYPE),linux)
+else
 $(TARGET): $(OBJECTS)
 	@echo "# linking "$@
 	@$(CC) $(LD_FLAGS) -o $(TARGET) $(addprefix $(OBJDIR)/, $(OBJECTS)) $(SHARED_LIBS)

--- a/webots_ros2_driver/webots/src/controller/cpp/Makefile
+++ b/webots_ros2_driver/webots/src/controller/cpp/Makefile
@@ -98,7 +98,11 @@ SHAREDLIBS    = -L$(WEBOTS_CONTROLLER_LIB_PATH) -lController
 CPPFLAGS      = -c -fPIC -Wall -mmacosx-version-min=$(MACOSX_MIN_SDK_VERSION)
 CPPINCLUDES   = -I$(WEBOTS_HOME_PATH)/include/controller/c -I$(WEBOTS_HOME_PATH)/include/controller/cpp
 LIBCONTROLLER = $(WEBOTS_CONTROLLER_LIB_PATH)/libController.dylib
+ifdef BUILD_MACOS_BUNDLE
 LDFLAGS      += -install_name @rpath/Contents/lib/controller/libCppController.dylib
+else
+LD_FLAGS     += -install_name @rpath/libCppController.dylib
+endif
 TARGET        = $(WEBOTS_CONTROLLER_LIB_PATH)/libCppController.dylib
 endif
 
@@ -117,15 +121,14 @@ endif
 
 all debug profile release: $(TARGET)
 
-ifeq ($(OSTYPE),darwin)
-
-X86_64_OBJECTS = $(addprefix $(BUILD_GOAL_DIR)/x86_64/,$(OBJECTS))
-ARM64_OBJECTS = $(addprefix $(BUILD_GOAL_DIR)/arm64/,$(OBJECTS))
+ifdef FAT_BINARY
+    ARM64_OBJECTS = $(addprefix $(BUILD_GOAL_DIR)/arm64/,$(OBJECTS))
+    X86_64_OBJECTS = $(addprefix $(BUILD_GOAL_DIR)/x86_64/,$(OBJECTS))
 
 $(TARGET): $(BUILD_GOAL_DIR)/x86_64/libCppController.dylib $(BUILD_GOAL_DIR)/arm64/libCppController.dylib
 	@echo "# creating fat" $(notdir $@)
 	@lipo -create -output $@ $(BUILD_GOAL_DIR)/x86_64/libCppController.dylib $(BUILD_GOAL_DIR)/arm64/libCppController.dylib
-	@codesign -s - $@
+	# @codesign -s - $@
 
 $(BUILD_GOAL_DIR)/x86_64/libCppController.dylib: $(X86_64_OBJECTS)
 	@echo "# linking" $@ "(x86_64)"

--- a/webots_ros2_driver/webots/src/controller/java/Makefile
+++ b/webots_ros2_driver/webots/src/controller/java/Makefile
@@ -112,7 +112,12 @@ CFLAGS1               = -isysroot $(MACOSX_SDK_PATH) -mmacosx-version-min=$(MACO
 PLATFORM_INCLUDE      = -I"$(MACOSX_SDK_PATH)/System/Library/Frameworks/JavaVM.framework/Versions/Current/Headers"
 TARGET                = $(WEBOTS_CONTROLLER_LIB_PATH)/java/lib$(LIBNAME).jnilib
 CFLAGS2               = -c -Wall -isysroot $(MACOSX_SDK_PATH) -mmacosx-version-min=$(MACOSX_MIN_SDK_VERSION) -Wno-unused-function
-JNILIB_FLAGS          = -dynamiclib -install_name @rpath/Contents/lib/controller/java/libJavaController.jnilib -Wl,-rpath,@loader_path/../../..
+JNILIB_FLAGS          = -dynamiclib -Wl,-rpath,@loader_path/../../..
+ifdef BUILD_MACOS_BUNDLE
+JNILIB_FLAGS          += -install_name @rpath/Contents/lib/controller/java/libJavaController.jnilib
+else
+JNILIB_FLAGS          += -install_name @rpath/java/libJavaController.jnilib
+endif
 JAVA_INCLUDES         = -I"$(JAVA_HOME)/include" -I"$(JAVA_HOME)/include/darwin"
 LIBCONTROLLER         = $(WEBOTS_CONTROLLER_LIB_PATH)/libController.dylib
 LIBCPPCONTROLLER      = $(WEBOTS_CONTROLLER_LIB_PATH)/libCppController.dylib
@@ -164,7 +169,7 @@ $(WEBOTS_CONTROLLER_LIB_PATH)/java/lib$(LIBNAME).jnilib: $(OBJDIR)/arm64/lib$(LI
 	@echo "# creating fat" $^
 	@mkdir -p $(WEBOTS_CONTROLLER_LIB_PATH)/java
 	lipo -create -output "$@" $(OBJDIR)/x86_64/lib$(LIBNAME).jnilib $(OBJDIR)/arm64/lib$(LIBNAME).jnilib
-	codesign -s - "$@"
+	# codesign -s - "$@"
 
 $(WEBOTS_CONTROLLER_LIB_PATH)/java/lib$(LIBNAME).so: $(WRAPPER_OBJECT)
 	@echo "# compiling" $^

--- a/webots_ros2_driver/webots_ros2_driver/utils.py
+++ b/webots_ros2_driver/webots_ros2_driver/utils.py
@@ -151,7 +151,7 @@ def get_webots_home(show_warning=False):
         return found >= minimum
 
     # Search in the environment variables
-    environment_variables = ['ROS2_WEBOTS_HOME', 'WEBOTS_HOME']
+    environment_variables = ['ROS2_WEBOTS_HOME', 'WEBOTS_HOME', 'WEBOTS_HOME_PATH']
     for variable in environment_variables:
         if variable in os.environ and os.path.isdir(os.environ[variable]) and WebotsVersion.from_path(os.environ[variable]):
             os.environ['WEBOTS_HOME'] = os.environ[variable]

--- a/webots_ros2_driver/webots_ros2_driver/webots_launcher.py
+++ b/webots_ros2_driver/webots_ros2_driver/webots_launcher.py
@@ -74,6 +74,8 @@ class WebotsLauncher(ExecuteProcess):
                 webots_path = get_webots_home()
             if self.__is_wsl:
                 webots_path = os.path.join(webots_path, 'msys64', 'mingw64', 'bin', 'webots.exe')
+            elif sys.platform == 'darwin':
+                webots_path = os.path.join(webots_path, 'MacOS', 'webots')
             else:
                 webots_path = os.path.join(webots_path, 'webots')
         else:

--- a/webots_ros2_msgs/CMakeLists.txt
+++ b/webots_ros2_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.15)
 project(webots_ros2_msgs)
 
 # Default to C11


### PR DESCRIPTION
**Description**
Currently webots_ros2 only builds natively on Ubuntu. Using Robostack, a partially supported ROS2 installation can also be done fairly easily. 
This pull requests makes some changes to the build process, so webots_ros2 also builds natively on MacOS.

**Affected Packages**
List of affected packages:
  - webots_ros2_driver
  - webots_ros2_msgs

**Tasks**
  - [ ] Find better way to build controller library on MacOS
  - [ ] Find better way to resolve dynamic library locations  
  - [ ] fix automatic download of webots

**Additional context**
This pull-request is pretty much WIP and not ready to be merged yet. 
Note that for testing purposes I made changes to the reduced webots source code (the one generated by sync_controller_lib.sh) directly here in the repository.

Currently the build process for MacOS always targets an Application Bundle build, i.e., resources and dynamic libraries are expected to be prefixed with `Contents/...`. As webots_ros2_driver only targets linux for now, it however expects files to be in the unprefixed location. For now I solved this by only conditionally prefixing paths determined by the variable `BUILD_MACOS_BUNDLE`. This however requires changes in the build process of webots. Another solution would be to leave the paths as they are, and change only webots_ros2_driver to use the files under the Contents prefix.

Further note that I bumped the minimum make version to version 3.15 to fix a problem with findPython module during the build process. If this is undesirable I can look If I find a workaround that does not depend on a version bump.