### PR TITLE
Fix universal robot example on Humble and Rolling

### DIFF
--- a/webots_ros2_control/src/Ros2Control.cpp
+++ b/webots_ros2_control/src/Ros2Control.cpp
@@ -41,7 +41,9 @@ namespace webots_ros2_control {
   void Ros2Control::step() {
     const int nowMs = wb_robot_get_time() * 1000.0;
     const int periodMs = nowMs - mLastControlUpdateMs;
+    // printf("%d - %d = %d\n", nowMs, mLastControlUpdateMs, periodMs);
     if (periodMs >= mControlPeriodMs) {
+      // printf("%d >= %d\n", periodMs, mControlPeriodMs);
       const rclcpp::Duration dt = rclcpp::Duration::from_seconds(mControlPeriodMs / 1000.0);
       mControllerManager->read(mNode->get_clock()->now(), dt);
 

--- a/webots_ros2_control/src/Ros2ControlSystem.cpp
+++ b/webots_ros2_control/src/Ros2ControlSystem.cpp
@@ -157,10 +157,13 @@ namespace webots_ros2_control {
   hardware_interface::return_type Ros2ControlSystem::write(const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/) {
     for (Joint &joint : mJoints) {
       if (joint.motor) {
-        if (joint.controlPosition && !std::isnan(joint.positionCommand))
+        if (joint.controlPosition && !std::isnan(joint.positionCommand)) {
           wb_motor_set_position(joint.motor, joint.positionCommand);
+          // printf("%s: position command = %f\n", wb_device_get_name(joint.motor), joint.positionCommand);
+        }
         if (joint.controlVelocity && !std::isnan(joint.velocityCommand)) {
-          // In the position control mode the velocity cannot be negative.
+          // printf("Velocity\n");
+          //  In the position control mode the velocity cannot be negative.
           const double velocityCommand = joint.controlPosition ? abs(joint.velocityCommand) : joint.velocityCommand;
           wb_motor_set_velocity(joint.motor, velocityCommand);
         }

--- a/webots_ros2_universal_robot/resource/ros2_control_abb_config.yaml
+++ b/webots_ros2_universal_robot/resource/ros2_control_abb_config.yaml
@@ -1,7 +1,7 @@
 /**:
   ros__parameters:
     # controller_manager
-    update_rate: 20
+    update_rate: 50
 
     abb_joint_trajectory_controller:
       type: joint_trajectory_controller/JointTrajectoryController

--- a/webots_ros2_universal_robot/resource/ros2_control_abb_config.yaml
+++ b/webots_ros2_universal_robot/resource/ros2_control_abb_config.yaml
@@ -22,6 +22,8 @@
       - finger_middle_joint_1
     command_interfaces:
       - position
+      - velocity
     state_interfaces:
       - position
+      - velocity
     allow_partial_joints_goal: True

--- a/webots_ros2_universal_robot/resource/ros2_control_config.yaml
+++ b/webots_ros2_universal_robot/resource/ros2_control_config.yaml
@@ -2,7 +2,7 @@
 /**:
   ros__parameters:
     # controller_manager
-    update_rate: 20
+    update_rate: 50
     ur_joint_trajectory_controller:
       type: joint_trajectory_controller/JointTrajectoryController
     ur_joint_state_broadcaster:

--- a/webots_ros2_universal_robot/resource/webots_abb_description.urdf
+++ b/webots_ros2_universal_robot/resource/webots_abb_description.urdf
@@ -13,72 +13,106 @@
         <joint name="A motor">
             <state_interface name="position"/>
             <command_interface name="position"/>
+            <state_interface name="velocity"/>
+            <command_interface name="velocity"/>
         </joint>
         <joint name="B motor">
             <state_interface name="position"/>
             <command_interface name="position"/>
+            <state_interface name="velocity"/>
+            <command_interface name="velocity"/>
         </joint>
         <joint name="C motor">
             <state_interface name="position"/>
             <command_interface name="position"/>
+            <state_interface name="velocity"/>
+            <command_interface name="velocity"/>
         </joint>
         <joint name="D motor">
             <state_interface name="position"/>
             <command_interface name="position"/>
+            <state_interface name="velocity"/>
+            <command_interface name="velocity"/>
         </joint>
         <joint name="E motor">
             <state_interface name="position"/>
             <command_interface name="position"/>
+            <state_interface name="velocity"/>
+            <command_interface name="velocity"/>
         </joint>
         <joint name="F motor">
             <state_interface name="position"/>
             <command_interface name="position"/>
+            <state_interface name="velocity"/>
+            <command_interface name="velocity"/>
         </joint>
 
         <!-- ROBOTIQ 3F Gripper -->
         <joint name="palm_finger_1_joint">
             <state_interface name="position"/>
             <command_interface name="position"/>
+            <state_interface name="velocity"/>
+            <command_interface name="velocity"/>
         </joint>
         <joint name="finger_1_joint_1">
             <state_interface name="position"/>
             <command_interface name="position"/>
+            <state_interface name="velocity"/>
+            <command_interface name="velocity"/>
         </joint>
         <joint name="finger_1_joint_2">
             <state_interface name="position"/>
             <command_interface name="position"/>
+            <state_interface name="velocity"/>
+            <command_interface name="velocity"/>
         </joint>
         <joint name="finger_1_joint_3">
             <state_interface name="position"/>
             <command_interface name="position"/>
+            <state_interface name="velocity"/>
+            <command_interface name="velocity"/>
         </joint>
         <joint name="palm_finger_2_joint">
             <state_interface name="position"/>
             <command_interface name="position"/>
+            <state_interface name="velocity"/>
+            <command_interface name="velocity"/>
         </joint>
         <joint name="finger_2_joint_1">
             <state_interface name="position"/>
             <command_interface name="position"/>
+            <state_interface name="velocity"/>
+            <command_interface name="velocity"/>
         </joint>
         <joint name="finger_2_joint_2">
             <state_interface name="position"/>
             <command_interface name="position"/>
+            <state_interface name="velocity"/>
+            <command_interface name="velocity"/>
         </joint>
         <joint name="finger_2_joint_3">
             <state_interface name="position"/>
             <command_interface name="position"/>
+            <state_interface name="velocity"/>
+            <command_interface name="velocity"/>
         </joint>
         <joint name="finger_middle_joint_1">
             <state_interface name="position"/>
             <command_interface name="position"/>
+            <state_interface name="velocity"/>
+            <command_interface name="velocity"/>
         </joint>
         <joint name="finger_middle_joint_2">
             <state_interface name="position"/>
             <command_interface name="position"/>
+            <state_interface name="velocity"/>
+            <command_interface name="velocity"/>
         </joint>
         <joint name="finger_middle_joint_3">
             <state_interface name="position"/>
             <command_interface name="position"/>
+            <state_interface name="velocity"/>
+            <command_interface name="velocity"/>
         </joint>
 
     </ros2_control>

--- a/webots_ros2_universal_robot/webots_ros2_universal_robot/abb_controller.py
+++ b/webots_ros2_universal_robot/webots_ros2_universal_robot/abb_controller.py
@@ -29,40 +29,54 @@ GOAL = {
         'finger_middle_joint_1'
     ],
     'points': [
-        {
-            'positions': [0.0, 0.0, 0.0, 0.0, 0.0495, 0.0495, 0.0495],
+        { #2sec:sim
+            'positions': [0.0, 0.0, 0.0, 0.0, 0.85, 0.85, 0.6],
+            'velocities': [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
             'time_from_start': {'sec': 0, 'nanosec': 0}
         },
-        {
+        { #reach above can : 3sec sim
             'positions': [-0.025, 0.0, 0.82, -0.86, 0.0495, 0.0495, 0.0495],
+            'velocities': [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
             'time_from_start': {'sec': 1, 'nanosec': 0}
         },
-        {
+        { #reach position grab but open : 4sec sim
             'positions': [-0.025, 0.1, 0.82, -0.86, 0.0495, 0.0495, 0.0495],
+            'velocities': [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0],
             'time_from_start': {'sec': 2, 'nanosec': 0}
         },
-        {
+        { #fermeture : 5sec sim
             'positions': [-0.025, 0.1, 0.82, -0.86, 0.85, 0.85, 0.6],
+            'velocities': [0.0, 0.0, 0.0, 0.0, 0.8, 0.8, 0.8],
             'time_from_start': {'sec': 3, 'nanosec': 0}
         },
-        {
+        { # relever bras de 50 cm: 5sec sim
             'positions': [-0.025, -0.44, 0.82, -0.86, 0.85, 0.85, 0.6],
+            'velocities': [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0],
             'time_from_start': {'sec': 4, 'nanosec': 0}
         },
-        {
+        { # tourner jusqua tapis roulant: 6sec sim
             'positions': [1.57, -0.05, 0.90, -0.71, 0.85, 0.85, 0.6],
+            'velocities': [3.0, 0.4, 3.0, 3.0, 0.0, 0.0, 0.0],
             'time_from_start': {'sec': 5, 'nanosec': 0}
         },
-        {
+        { # lacher la can: 7sec sim
             'positions': [1.57, -0.05, 0.75, -0.81, 0.0495, 0.0495, 0.0495],
+            'velocities': [0.0, 0.0, 0.4, 0.4, 1.5, 1.5, 1.5],
             'time_from_start': {'sec': 6, 'nanosec': 0}
         },
-        {
-            'positions': [0.0, 0.0, 0.0, 0.0, 0.0495, 0.0495, 0.0495],
+        { # retour pos initiale: 8sec
+            'positions': [1.57, 0.0, 0.0, 0.0, 0.0495, 0.0495, 0.0495],
+            'velocities': [0.0, 2.0, 2.0, 2.0, 0.0, 0.0, 0.0],
             'time_from_start': {'sec': 7, 'nanosec': 0}
         },
         {
             'positions': [0.0, 0.0, 0.0, 0.0, 0.0495, 0.0495, 0.0495],
+            'velocities': [2.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            'time_from_start': {'sec': 8, 'nanosec': 0}
+        },
+        {
+            'positions': [0.0, 0.0, 0.0, 0.0, 0.0495, 0.0495, 0.0495],
+            'velocities': [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
             'time_from_start': {'sec': 9, 'nanosec': 0}
         }
     ]

--- a/webots_ros2_universal_robot/webots_ros2_universal_robot/follow_joint_trajectory_client.py
+++ b/webots_ros2_universal_robot/webots_ros2_universal_robot/follow_joint_trajectory_client.py
@@ -92,6 +92,7 @@ class FollowJointTrajectoryClient(Node):
         for point in trajectory['points']:
             trajectory_point = JointTrajectoryPoint(
                 positions=point['positions'],
+                velocities=point['velocities'],
                 time_from_start=Duration(
                     sec=point['time_from_start']['sec'],
                     nanosec=point['time_from_start']['nanosec']

--- a/webots_ros2_universal_robot/webots_ros2_universal_robot/ur5e_controller.py
+++ b/webots_ros2_universal_robot/webots_ros2_universal_robot/ur5e_controller.py
@@ -31,34 +31,52 @@ GOAL = {
     'points': [
         {
             'positions': [0.0, 0.0, 0.0, 0.0, 0.0495, 0.0495, 0.0495],
+            'velocities': [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
             'time_from_start': {'sec': 0, 'nanosec': 0}
         },
         {
             'positions': [0.0, 0.0, 0.0, 0.0, 0.0495, 0.0495, 0.0495],
-            'time_from_start': {'sec': 3, 'nanosec': 0}
+            'velocities': [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            'time_from_start': {'sec': 1, 'nanosec': 0}
         },
         {
             'positions': [0.0, 0.0, 0.0, 0.0, 0.85, 0.85, 0.6],
-            'time_from_start': {'sec': 4, 'nanosec': 0}
+            'velocities': [0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0],
+            'time_from_start': {'sec': 2, 'nanosec': 0}
+        },
+        {
+            'positions': [0.0, 0.0, 0.0, 0.0, 0.85, 0.85, 0.6],
+            'velocities': [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            'time_from_start': {'sec': 3, 'nanosec': 0}
         },
         {
             'positions': [0.63, -2.26, -1.88, -2.14, 0.85, 0.85, 0.6],
-            'time_from_start': {'sec': 5, 'nanosec': 0}
+            'velocities': [1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0],
+            'time_from_start': {'sec': 4, 'nanosec': 0}
         },
         {
             'positions': [0.63, -2.26, -1.88, -2.14, 0.0495, 0.0495, 0.0495],
-            'time_from_start': {'sec': 6, 'nanosec': 0}
+            'velocities': [0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0],
+            'time_from_start': {'sec': 5, 'nanosec': 0}
         },
         {
             'positions': [0.63, -2.0, -1.88, -2.14, 0.0495, 0.0495, 0.0495],
+            'velocities': [0.0, 0.7, 0.0, 0.0, 0.0, 0.0, 0.0],
+            'time_from_start': {'sec': 6, 'nanosec': 0}
+        },
+        {
+            'positions': [0.0, 0.0, 0.0, 0.0, 0.0495, 0.0495, 0.0495],
+            'velocities': [1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0],
             'time_from_start': {'sec': 7, 'nanosec': 0}
         },
         {
             'positions': [0.0, 0.0, 0.0, 0.0, 0.0495, 0.0495, 0.0495],
+            'velocities': [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
             'time_from_start': {'sec': 8, 'nanosec': 0}
         },
         {
             'positions': [0.0, 0.0, 0.0, 0.0, 0.0495, 0.0495, 0.0495],
+            'velocities': [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
             'time_from_start': {'sec': 9, 'nanosec': 0}
         }
     ]

--- a/webots_ros2_universal_robot/worlds/robotic_arms.wbt
+++ b/webots_ros2_universal_robot/worlds/robotic_arms.wbt
@@ -40,7 +40,7 @@ EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2023a/project
 
 WorldInfo {
   title "ROS2-Webots Armed Robots Demo"
-  basicTimeStep 16
+  basicTimeStep 20
   contactProperties [
     ContactProperties {
       bounce 0.3


### PR DESCRIPTION
On Humble and Rolling, the universal robot example is not running as smooth as on Foxy and the cans often fall on the ground. This also results in random fails in the corresponding CI test.
See the related issue on the `ros-controls` repository: https://github.com/ros-controls/ros2_controllers/issues/545.

**FOXY**

https://user-images.githubusercontent.com/61198661/237051774-dd9cef4b-85e6-4ed6-a020-bc774b5a8555.mp4

**HUMBLE**

https://user-images.githubusercontent.com/61198661/237051782-0fd4458a-d953-4cba-95b5-170f9ec096fe.mp4

