### PR TITLE
Feature WebotsController node

### DIFF
--- a/webots_ros2/CHANGELOG.rst
+++ b/webots_ros2/CHANGELOG.rst
@@ -5,6 +5,7 @@ Changelog for package webots_ros2
 2023.1.0 (2023-XX-XX)
 ------------------
 * Added new TIAGo project to webots_ros2_tiago to run real robot configuration.
+* Added new WebotsController node in the driver interface to launch robot controller plugins.
 
 2023.0.4 (2023-XX-XX)
 ------------------

--- a/webots_ros2_driver/CHANGELOG.rst
+++ b/webots_ros2_driver/CHANGELOG.rst
@@ -5,6 +5,7 @@ Changelog for package webots_ros2_driver
 2023.1.0 (2023-XX-XX)
 ------------------
 * Added parameters to rename Camera and RangeFinder topics.
+* Added new WebotsController node to launch robot controller plugins.
 
 2023.0.4 (2023-XX-XX)
 ------------------

--- a/webots_ros2_driver/CMakeLists.txt
+++ b/webots_ros2_driver/CMakeLists.txt
@@ -81,7 +81,6 @@ ament_python_install_package(${PROJECT_NAME}
   PACKAGE_DIR ${PROJECT_NAME})
 
 # Driver
-set(CMAKE_INSTALL_RPATH "$ORIGIN/../controller")
 add_executable(driver
   src/Driver.cpp
   src/WebotsNode.cpp
@@ -129,7 +128,6 @@ install(TARGETS driver
 )
 
 # Dynamic IMU
-set(CMAKE_INSTALL_RPATH "$ORIGIN/controller")
 add_library(
   ${PROJECT_NAME}_imu
   SHARED
@@ -157,7 +155,6 @@ install(TARGETS ${PROJECT_NAME}_imu
 )
 
 # Dynamic RGBD
-set(CMAKE_INSTALL_RPATH "$ORIGIN/controller")
 add_library(
   ${PROJECT_NAME}_rgbd
   SHARED

--- a/webots_ros2_driver/CMakeLists.txt
+++ b/webots_ros2_driver/CMakeLists.txt
@@ -223,6 +223,12 @@ install(
   DESTINATION share/${PROJECT_NAME}/scripts
 )
 
+# Install webots-controller script
+install(
+  PROGRAMS webots/webots-controller
+  DESTINATION share/${PROJECT_NAME}/scripts
+)
+
 # Ament export
 set(WEBOTS_LIB_PATH
   controller/${CMAKE_SHARED_LIBRARY_PREFIX}Controller${CMAKE_SHARED_LIBRARY_SUFFIX}

--- a/webots_ros2_driver/include/webots_ros2_driver/WebotsNode.hpp
+++ b/webots_ros2_driver/include/webots_ros2_driver/WebotsNode.hpp
@@ -47,6 +47,7 @@ namespace webots_ros2_driver {
     void setAnotherNodeParameter(std::string anotherNodeName, std::string parameterName, std::string parameterValue);
     rclcpp::Client<rcl_interfaces::srv::SetParameters>::SharedPtr mClient;
 
+    std::string mRobotDescriptionParam;
     std::string mRobotDescription;
     bool mSetRobotStatePublisher;
 

--- a/webots_ros2_driver/src/PythonPlugin.cpp
+++ b/webots_ros2_driver/src/PythonPlugin.cpp
@@ -29,11 +29,6 @@ namespace webots_ros2_driver {
 import os
 import sys
 
-# Set WEBOTS_HOME to the webots_ros2_driver installation folder
-# to load the correct libController libraries from the Python API
-from ament_index_python.packages import get_package_prefix
-os.environ['WEBOTS_HOME'] = get_package_prefix('webots_ros2_driver')
-
 import controller
 from controller import Supervisor
 

--- a/webots_ros2_driver/src/WebotsNode.cpp
+++ b/webots_ros2_driver/src/WebotsNode.cpp
@@ -44,9 +44,7 @@ namespace webots_ros2_driver {
 
   bool gShutdownSignalReceived = false;
 
-  void handleSigint(int sig) {
-    gShutdownSignalReceived = true;
-  }
+  void handleSigint(int sig) { gShutdownSignalReceived = true; }
 
   WebotsNode::WebotsNode(std::string name) : Node(name), mPluginLoader(gPluginInterfaceName, gPluginInterface) {
     mRobotDescriptionParam = this->declare_parameter<std::string>("robot_description", "");
@@ -65,7 +63,6 @@ namespace webots_ros2_driver {
           command += " ";
           command += xacroMapping;
         }
-        RCLCPP_INFO(get_logger(), "\033[33m%s\033[0m", command.c_str());
 
         FILE *stream = popen(command.c_str(), "r");
         if (!stream)
@@ -101,7 +98,6 @@ namespace webots_ros2_driver {
     tinyxml2::XMLPrinter printer;
     mRobotDescriptionDocument->Accept(&printer);
     mRobotDescription = printer.CStr();
-    RCLCPP_INFO(get_logger(), "URDF content:\n%s", mRobotDescription.c_str());
 
     mRemoveUrdfRobotPublisher = create_publisher<std_msgs::msg::String>("/remove_urdf_robot", rclcpp::ServicesQoS());
     mRemoveUrdfRobotMessage.data = name;
@@ -280,7 +276,5 @@ namespace webots_ros2_driver {
     mClient->async_send_request(request);
   }
 
-  void WebotsNode::handleSignals() {
-    signal(SIGINT, handleSigint);
-  }
+  void WebotsNode::handleSignals() { signal(SIGINT, handleSigint); }
 }  // end namespace webots_ros2_driver

--- a/webots_ros2_driver/src/WebotsNode.cpp
+++ b/webots_ros2_driver/src/WebotsNode.cpp
@@ -44,16 +44,51 @@ namespace webots_ros2_driver {
 
   bool gShutdownSignalReceived = false;
 
-  void handleSigint(int sig) { gShutdownSignalReceived = true; }
+  void handleSigint(int sig) {
+    gShutdownSignalReceived = true;
+  }
 
   WebotsNode::WebotsNode(std::string name) : Node(name), mPluginLoader(gPluginInterfaceName, gPluginInterface) {
-    mRobotDescription = this->declare_parameter<std::string>("robot_description", "");
+    mRobotDescriptionParam = this->declare_parameter<std::string>("robot_description", "");
     mSetRobotStatePublisher = this->declare_parameter<bool>("set_robot_state_publisher", false);
-    if (mRobotDescription != "") {
+    if (mRobotDescriptionParam != "") {
       mRobotDescriptionDocument = std::make_shared<tinyxml2::XMLDocument>();
-      mRobotDescriptionDocument->Parse(mRobotDescription.c_str());
+      // Path to URDF file
+      if (mRobotDescriptionParam.rfind(".urdf") == mRobotDescriptionParam.size() - 5)
+        mRobotDescriptionDocument->LoadFile(mRobotDescriptionParam.c_str());
+      // Path to Xacro file
+      else if (mRobotDescriptionParam.rfind(".xacro") == mRobotDescriptionParam.size() - 6) {
+        std::vector<std::string> xacroMappings =
+          this->declare_parameter<std::vector<std::string>>("xacro_mappings", std::vector<std::string>());
+        std::string command = "ros2 run xacro xacro " + mRobotDescriptionParam;
+        for (const std::string &xacroMapping : xacroMappings) {
+          command += " ";
+          command += xacroMapping;
+        }
+        RCLCPP_INFO(get_logger(), "\033[33m%s\033[0m", command.c_str());
+
+        FILE *stream = popen(command.c_str(), "r");
+        if (!stream)
+          throw std::runtime_error("Failed to execute xacro command");
+
+        char buffer[4096];
+        std::string xacroOutput;
+        while (fgets(buffer, sizeof(buffer), stream) != NULL)
+          xacroOutput += buffer;
+        pclose(stream);
+
+        mRobotDescriptionDocument->Parse(xacroOutput.c_str());
+      }
+      // Full string (deprecated)
+      else {
+        mRobotDescriptionDocument->Parse(mRobotDescriptionParam.c_str());
+        RCLCPP_WARN(
+          get_logger(),
+          "\033[33mPassing robot description as a string is deprecated. Provide the URDF or Xacro file path instead.\033[0m");
+      }
       if (!mRobotDescriptionDocument)
-        throw std::runtime_error("Invalid URDF, it cannot be parsed");
+        throw std::runtime_error("Invalid robot description, it cannot be parsed");
+      // Access the robot and webots elements as needed
       tinyxml2::XMLElement *robotXMLElement = mRobotDescriptionDocument->FirstChildElement("robot");
       if (!robotXMLElement)
         throw std::runtime_error("Invalid URDF, it doesn't contain a <robot> tag");
@@ -62,6 +97,11 @@ namespace webots_ros2_driver {
       mWebotsXMLElement = NULL;
       RCLCPP_INFO(get_logger(), "Robot description is not passed, using default parameters.");
     }
+    // Store robot description string in mRobotDescription
+    tinyxml2::XMLPrinter printer;
+    mRobotDescriptionDocument->Accept(&printer);
+    mRobotDescription = printer.CStr();
+    RCLCPP_INFO(get_logger(), "URDF content:\n%s", mRobotDescription.c_str());
 
     mRemoveUrdfRobotPublisher = create_publisher<std_msgs::msg::String>("/remove_urdf_robot", rclcpp::ServicesQoS());
     mRemoveUrdfRobotMessage.data = name;
@@ -240,5 +280,7 @@ namespace webots_ros2_driver {
     mClient->async_send_request(request);
   }
 
-  void WebotsNode::handleSignals() { signal(SIGINT, handleSigint); }
+  void WebotsNode::handleSignals() {
+    signal(SIGINT, handleSigint);
+  }
 }  // end namespace webots_ros2_driver

--- a/webots_ros2_driver/webots_ros2_driver/utils.py
+++ b/webots_ros2_driver/webots_ros2_driver/utils.py
@@ -135,6 +135,16 @@ def get_host_ip():
         sys.exit('Unable to get host IP address. \'ip route\' could not be executed.')
 
 
+def controller_protocol():
+    protocol = 'tcp' if (has_shared_folder() or is_wsl()) else 'ipc'
+    return protocol
+
+
+def controller_ip_address():
+    ip_address = get_host_ip() if has_shared_folder() else get_wsl_ip_address()
+    return ip_address
+
+
 def controller_url_prefix(port='1234'):
     if has_shared_folder() or is_wsl():
         return 'tcp://' + (get_host_ip() if has_shared_folder() else get_wsl_ip_address()) + ':' + port + '/'

--- a/webots_ros2_driver/webots_ros2_driver/webots_controller.py
+++ b/webots_ros2_driver/webots_ros2_driver/webots_controller.py
@@ -58,8 +58,6 @@ class WebotsController(ExecuteProcess):
         ros_args = ['--ros-args'] if ros_arguments else []
         params_file = ['--params-file'] if file_parameters else []
 
-        # Set WEBOTS_HOME to package directory to load correct controller library
-        os.environ['WEBOTS_HOME'] = get_package_prefix('webots_ros2_driver')
         node_name = 'webots_controller' + (('_' + robot_name) if robot_name else '')
         super().__init__(
             output=output,
@@ -76,6 +74,8 @@ class WebotsController(ExecuteProcess):
                 *file_parameters,
             ],
             name=node_name,
+            # Set WEBOTS_HOME to package directory to load correct controller library
+            additional_env={'WEBOTS_HOME': get_package_prefix('webots_ros2_driver')},
             **kwargs
         )
 

--- a/webots_ros2_driver/webots_ros2_driver/webots_controller.py
+++ b/webots_ros2_driver/webots_ros2_driver/webots_controller.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+
+# Copyright 1996-2023 Cyberbotics Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""This launcher simply starts Webots."""
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from launch.actions import ExecuteProcess
+from launch_ros.actions import Node
+from launch.launch_context import LaunchContext
+from launch.substitution import Substitution
+from launch.substitutions import TextSubstitution
+from launch.substitutions.path_join_substitution import PathJoinSubstitution
+from ament_index_python.packages import get_package_share_directory, get_package_prefix
+
+from webots_ros2_driver.utils import controller_protocol, controller_ip_address
+
+
+class _ConditionalSubstitution(Substitution):
+    def __init__(self, *, condition, false_value='', true_value=''):
+        self.__condition = condition if isinstance(condition, Substitution) else TextSubstitution(text=str(condition))
+        self.__false_value = false_value if isinstance(false_value, Substitution) else TextSubstitution(text=false_value)
+        self.__true_value = true_value if isinstance(true_value, Substitution) else TextSubstitution(text=true_value)
+
+    def perform(self, context):
+        if context.perform_substitution(self.__condition).lower() in ['false', '0', '']:
+            return context.perform_substitution(self.__false_value)
+        return context.perform_substitution(self.__true_value)
+
+
+class WebotsController(ExecuteProcess):
+    def __init__(self, output='screen', parameters=None, robot_name='', port='1234', **kwargs):
+        webots_controller = (os.path.join(get_package_share_directory('webots_ros2_driver'), 'scripts', 'webots-controller'))
+
+        protocol = controller_protocol()
+        ip_address = controller_ip_address() if (protocol == 'tcp') else ''
+
+        robot_name_option = _ConditionalSubstitution(condition=robot_name, true_value='--robot-name=' + robot_name)
+        ip_address_option = _ConditionalSubstitution(condition=ip_address, true_value='--ip-address=' + ip_address)
+
+        # Get parameters and check if file (yaml extensions) or if single param
+        single_parameters = " ".join([f"{key}:={value}" for item in parameters if isinstance(item, dict) for key, value in item.items()])
+        file_parameters = " ".join([item for item in parameters if isinstance(item, str)])
+
+        ros_args = _ConditionalSubstitution(condition=single_parameters, true_value='--ros-args')
+        params_file = _ConditionalSubstitution(condition=file_parameters, true_value='--params-file')
+
+        single_parameters_options = _ConditionalSubstitution(condition=single_parameters, true_value=single_parameters)
+        file_parameters_options = _ConditionalSubstitution(condition=file_parameters, true_value=file_parameters)
+
+        super().__init__(
+            output=output,
+            cmd=[
+                webots_controller,
+                robot_name_option,
+                ['--protocol=', protocol],
+                ip_address_option,
+                ['--port=', port],
+                'ros2',
+                ros_args,
+                single_parameters_options,
+                params_file,
+                file_parameters_options,
+            ],
+            name='webots_tcp_client',
+            **kwargs
+        )
+
+    def execute(self, context: LaunchContext):
+
+        # Execute process
+        return super().execute(context)
+
+    def _shutdown_process(self, context, *, send_sigint):
+
+        return super()._shutdown_process(context, send_sigint=send_sigint)

--- a/webots_ros2_driver/webots_ros2_driver/webots_controller.py
+++ b/webots_ros2_driver/webots_ros2_driver/webots_controller.py
@@ -18,7 +18,6 @@
 
 import os
 
-import launch
 from launch.actions import ExecuteProcess
 from launch.launch_context import LaunchContext
 from launch.substitution import Substitution

--- a/webots_ros2_driver/webots_ros2_driver/webots_controller.py
+++ b/webots_ros2_driver/webots_ros2_driver/webots_controller.py
@@ -28,7 +28,7 @@ from webots_ros2_driver.utils import controller_protocol, controller_ip_address
 
 
 class WebotsController(ExecuteProcess):
-    def __init__(self, output='screen', parameters=[], remappings=[], robot_name='', port='1234', **kwargs):
+    def __init__(self, output='screen', remappings=[], namespace='', parameters=[], robot_name='', port='1234', **kwargs):
         webots_controller = (os.path.join(get_package_share_directory('webots_ros2_driver'), 'scripts', 'webots-controller'))
 
         protocol = controller_protocol()
@@ -41,6 +41,10 @@ class WebotsController(ExecuteProcess):
         for item in remappings:
             key, value = item
             remap = f'{key}:={value}'
+            ros_arguments.append('-r')
+            ros_arguments.append(remap)
+        if (namespace):
+            remap = f'__ns:=/{namespace}'
             ros_arguments.append('-r')
             ros_arguments.append(remap)
         for item in parameters:

--- a/webots_ros2_epuck/CHANGELOG.rst
+++ b/webots_ros2_epuck/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package webots_ros2_epuck
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2023.1.0 (2023-XX-XX)
+------------------
+* Update driver node to new WebotsController node.
+
 2023.0.4 (2023-XX-XX)
 ------------------
 * Fixed ability to launch RViz without other tools.

--- a/webots_ros2_epuck/launch/robot_launch.py
+++ b/webots_ros2_epuck/launch/robot_launch.py
@@ -27,7 +27,7 @@ from launch import LaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from ament_index_python.packages import get_package_share_directory
 from webots_ros2_driver.webots_launcher import WebotsLauncher
-from webots_ros2_driver.utils import controller_url_prefix
+from webots_ros2_driver.webots_controller import WebotsController
 
 
 def get_ros2_nodes(*args):
@@ -71,11 +71,8 @@ def get_ros2_nodes(*args):
     if 'ROS_DISTRO' in os.environ and os.environ['ROS_DISTRO'] in ['humble', 'rolling']:
         mappings.append(('/diffdrive_controller/odom', '/odom'))
 
-    epuck_driver = Node(
-        package='webots_ros2_driver',
-        executable='driver',
-        output='screen',
-        additional_env={'WEBOTS_CONTROLLER_URL': controller_url_prefix() + 'e-puck'},
+    epuck_driver = WebotsController(
+        robot_name='e-puck',
         parameters=[
             {'robot_description': robot_description,
              'use_sim_time': use_sim_time,

--- a/webots_ros2_epuck/launch/robot_launch.py
+++ b/webots_ros2_epuck/launch/robot_launch.py
@@ -17,7 +17,6 @@
 """Launch Webots e-puck driver."""
 
 import os
-import pathlib
 import launch
 from launch.substitutions import LaunchConfiguration
 from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
@@ -37,7 +36,7 @@ def get_ros2_nodes(*args):
     use_mapper = LaunchConfiguration('mapper', default=False)
     fill_map = LaunchConfiguration('fill_map', default=True)
     map_filename = LaunchConfiguration('map', default=os.path.join(package_dir, 'resource', 'epuck_world_map.yaml'))
-    robot_description = pathlib.Path(os.path.join(package_dir, 'resource', 'epuck_webots.urdf')).read_text()
+    robot_description_path = os.path.join(package_dir, 'resource', 'epuck_webots.urdf')
     ros2_control_params = os.path.join(package_dir, 'resource', 'ros2_control.yml')
     use_sim_time = LaunchConfiguration('use_sim_time', default=True)
     controller_manager_timeout = ['--controller-manager-timeout', '50']
@@ -74,7 +73,7 @@ def get_ros2_nodes(*args):
     epuck_driver = WebotsController(
         robot_name='e-puck',
         parameters=[
-            {'robot_description': robot_description,
+            {'robot_description': robot_description_path,
              'use_sim_time': use_sim_time,
              'set_robot_state_publisher': True},
             ros2_control_params

--- a/webots_ros2_mavic/CHANGELOG.rst
+++ b/webots_ros2_mavic/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package webots_ros2_mavic
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2023.1.0 (2023-XX-XX)
+------------------
+* Update driver node to new WebotsController node.
+
 2023.0.2 (2023-02-07)
 ------------------
 * Updated supervisor launch.

--- a/webots_ros2_mavic/launch/robot_launch.py
+++ b/webots_ros2_mavic/launch/robot_launch.py
@@ -22,22 +22,18 @@ import launch
 from launch.substitutions import LaunchConfiguration
 from launch.actions import DeclareLaunchArgument
 from launch.substitutions.path_join_substitution import PathJoinSubstitution
-from launch_ros.actions import Node
 from launch import LaunchDescription
 from ament_index_python.packages import get_package_share_directory
 from webots_ros2_driver.webots_launcher import WebotsLauncher
-from webots_ros2_driver.utils import controller_url_prefix
+from webots_ros2_driver.webots_controller import WebotsController
 
 
 def get_ros2_nodes(*args):
     package_dir = get_package_share_directory('webots_ros2_mavic')
     robot_description = pathlib.Path(os.path.join(package_dir, 'resource', 'mavic_webots.urdf')).read_text()
 
-    mavic_driver = Node(
-        package='webots_ros2_driver',
-        executable='driver',
-        output='screen',
-        additional_env={'WEBOTS_CONTROLLER_URL': controller_url_prefix() + 'Mavic_2_PRO'},
+    mavic_driver = WebotsController(
+        robot_name='Mavic_2_PRO',
         parameters=[
             {'robot_description': robot_description},
         ]

--- a/webots_ros2_mavic/launch/robot_launch.py
+++ b/webots_ros2_mavic/launch/robot_launch.py
@@ -17,7 +17,6 @@
 """Launch Webots Mavic 2 Pro driver."""
 
 import os
-import pathlib
 import launch
 from launch.substitutions import LaunchConfiguration
 from launch.actions import DeclareLaunchArgument
@@ -30,12 +29,12 @@ from webots_ros2_driver.webots_controller import WebotsController
 
 def get_ros2_nodes(*args):
     package_dir = get_package_share_directory('webots_ros2_mavic')
-    robot_description = pathlib.Path(os.path.join(package_dir, 'resource', 'mavic_webots.urdf')).read_text()
+    robot_description_path = os.path.join(package_dir, 'resource', 'mavic_webots.urdf')
 
     mavic_driver = WebotsController(
         robot_name='Mavic_2_PRO',
         parameters=[
-            {'robot_description': robot_description},
+            {'robot_description': robot_description_path},
         ]
     )
 

--- a/webots_ros2_tesla/CHANGELOG.rst
+++ b/webots_ros2_tesla/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package webots_ros2_tesla
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2023.1.0 (2023-XX-XX)
+------------------
+* Update driver node to new WebotsController node.
+
 2023.0.2 (2023-02-07)
 ------------------
 * Updated supervisor launch.

--- a/webots_ros2_tesla/launch/robot_launch.py
+++ b/webots_ros2_tesla/launch/robot_launch.py
@@ -17,7 +17,6 @@
 """Launch Webots Tesla driver."""
 
 import os
-import pathlib
 import launch
 from launch.substitutions import LaunchConfiguration
 from launch.actions import DeclareLaunchArgument
@@ -31,12 +30,12 @@ from webots_ros2_driver.webots_controller import WebotsController
 
 def get_ros2_nodes(*args):
     package_dir = get_package_share_directory('webots_ros2_tesla')
-    robot_description = pathlib.Path(os.path.join(package_dir, 'resource', 'tesla_webots.urdf')).read_text()
+    robot_description_path = os.path.join(package_dir, 'resource', 'tesla_webots.urdf')
 
     tesla_driver = WebotsController(
         robot_name='vehicle',
         parameters=[
-            {'robot_description': robot_description}
+            {'robot_description': robot_description_path}
         ]
     )
 

--- a/webots_ros2_tesla/launch/robot_launch.py
+++ b/webots_ros2_tesla/launch/robot_launch.py
@@ -26,20 +26,17 @@ from launch import LaunchDescription
 from ament_index_python.packages import get_package_share_directory
 from launch_ros.actions import Node
 from webots_ros2_driver.webots_launcher import WebotsLauncher
-from webots_ros2_driver.utils import controller_url_prefix
+from webots_ros2_driver.webots_controller import WebotsController
 
 
 def get_ros2_nodes(*args):
     package_dir = get_package_share_directory('webots_ros2_tesla')
     robot_description = pathlib.Path(os.path.join(package_dir, 'resource', 'tesla_webots.urdf')).read_text()
 
-    tesla_driver = Node(
-        package='webots_ros2_driver',
-        executable='driver',
-        output='screen',
-        additional_env={'WEBOTS_CONTROLLER_URL': controller_url_prefix() + 'vehicle'},
+    tesla_driver = WebotsController(
+        robot_name='vehicle',
         parameters=[
-            {'robot_description': robot_description},
+            {'robot_description': robot_description}
         ]
     )
 

--- a/webots_ros2_tests/CHANGELOG.rst
+++ b/webots_ros2_tests/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package webots_ros2_tests
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2023.1.0 (2023-XX-XX)
+------------------
+* Update webots_ros2_driver test to new WebotsController node.
+
 2023.0.4 (2023-XX-XX)
 ------------------
 * Added support for painted point clouds

--- a/webots_ros2_tests/test/test_system_driver.py
+++ b/webots_ros2_tests/test/test_system_driver.py
@@ -20,7 +20,6 @@
 
 import os
 import time
-import pathlib
 import pytest
 import rclpy
 from sensor_msgs.msg import LaserScan, PointCloud2
@@ -35,8 +34,8 @@ import launch
 import launch_testing.actions
 from ament_index_python.packages import get_package_share_directory
 from webots_ros2_driver.webots_launcher import WebotsLauncher
+from webots_ros2_driver.webots_controller import WebotsController
 from webots_ros2_tests.utils import TestWebots, initialize_webots_test
-from webots_ros2_driver.utils import controller_url_prefix
 
 
 @pytest.mark.rostest
@@ -44,7 +43,7 @@ def generate_test_description():
     initialize_webots_test()
 
     package_dir = get_package_share_directory('webots_ros2_tests')
-    robot_description = pathlib.Path(os.path.join(package_dir, 'resource', 'driver_test.urdf')).read_text()
+    robot_description_path = os.path.join(package_dir, 'resource', 'driver_test.urdf')
 
     webots = WebotsLauncher(
         world=os.path.join(package_dir, 'worlds', 'driver_test.wbt'),
@@ -53,12 +52,9 @@ def generate_test_description():
         ros2_supervisor=True
     )
 
-    webots_driver = Node(
-        package='webots_ros2_driver',
-        executable='driver',
-        output='screen',
-        additional_env={'WEBOTS_CONTROLLER_URL': controller_url_prefix() + 'Pioneer_3_AT'},
-        parameters=[{'robot_description': robot_description, 'use_sim_time': True}]
+    webots_driver = WebotsController(
+        robot_name='Pioneer_3_AT',
+        parameters=[{'robot_description': robot_description_path, 'use_sim_time': True}]
     )
 
     return LaunchDescription([

--- a/webots_ros2_tests/test/test_system_driver.py
+++ b/webots_ros2_tests/test/test_system_driver.py
@@ -29,7 +29,6 @@ from std_msgs.msg import Int32, Float32
 from geometry_msgs.msg import PointStamped, Vector3
 from webots_ros2_msgs.msg import CameraRecognitionObjects
 from launch import LaunchDescription
-from launch_ros.actions import Node
 import launch
 import launch_testing.actions
 from ament_index_python.packages import get_package_share_directory

--- a/webots_ros2_tiago/CHANGELOG.rst
+++ b/webots_ros2_tiago/CHANGELOG.rst
@@ -5,6 +5,7 @@ Changelog for package webots_ros2_tiago
 2023.1.0 (2023-XX-XX)
 ------------------
 * Added new world, resources and launch file to start the TIAGo with real robot configuration.
+* Update driver node to new WebotsController node.
 
 2023.0.4 (2023-XX-XX)
 ------------------

--- a/webots_ros2_tiago/launch/robot_bringup_launch.py
+++ b/webots_ros2_tiago/launch/robot_bringup_launch.py
@@ -28,7 +28,7 @@ from ament_index_python.packages import get_package_share_directory
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.actions import IncludeLaunchDescription
 from webots_ros2_driver.webots_launcher import WebotsLauncher
-from webots_ros2_driver.utils import controller_url_prefix
+from webots_ros2_driver.webots_controller import WebotsController
 
 
 def launch_spawners(event, nodes):
@@ -45,11 +45,8 @@ def get_ros2_nodes(*args):
     ros2_control_params = os.path.join(package_dir, 'resource', 'ros2_control_bringup.yml')
     use_sim_time = LaunchConfiguration('use_sim_time', default=True)
 
-    tiago_driver = Node(
-        package='webots_ros2_driver',
-        executable='driver',
-        output='screen',
-        additional_env={'WEBOTS_CONTROLLER_URL': controller_url_prefix() + 'Tiago'},
+    tiago_driver = WebotsController(
+        robot_name='Tiago',
         parameters=[
             {'robot_description': robot_description,
              'use_sim_time': use_sim_time},

--- a/webots_ros2_tiago/launch/robot_bringup_launch.py
+++ b/webots_ros2_tiago/launch/robot_bringup_launch.py
@@ -17,7 +17,6 @@
 """Launch Webots and the controller."""
 
 import os
-import pathlib
 import launch
 from launch.substitutions import LaunchConfiguration
 from launch.actions import DeclareLaunchArgument
@@ -41,14 +40,14 @@ def launch_spawners(event, nodes):
 def get_ros2_nodes(*args):
     package_dir = get_package_share_directory('webots_ros2_tiago')
     use_rviz = LaunchConfiguration('rviz', default=False)
-    robot_description = pathlib.Path(os.path.join(package_dir, 'resource', 'tiago_bringup_webots.urdf')).read_text()
+    robot_description_path = os.path.join(package_dir, 'resource', 'tiago_bringup_webots.urdf')
     ros2_control_params = os.path.join(package_dir, 'resource', 'ros2_control_bringup.yml')
     use_sim_time = LaunchConfiguration('use_sim_time', default=True)
 
     tiago_driver = WebotsController(
         robot_name='Tiago',
         parameters=[
-            {'robot_description': robot_description,
+            {'robot_description': robot_description_path,
              'use_sim_time': use_sim_time},
             ros2_control_params
         ]

--- a/webots_ros2_tiago/launch/robot_launch.py
+++ b/webots_ros2_tiago/launch/robot_launch.py
@@ -17,7 +17,6 @@
 """Launch Webots and the controller."""
 
 import os
-import pathlib
 import launch
 from launch.substitutions import LaunchConfiguration
 from launch.actions import DeclareLaunchArgument
@@ -44,7 +43,7 @@ def get_ros2_nodes(*args):
     use_nav = LaunchConfiguration('nav', default=False)
     use_slam_toolbox = LaunchConfiguration('slam_toolbox', default=False)
     use_slam_cartographer = LaunchConfiguration('slam_cartographer', default=False)
-    robot_description = pathlib.Path(os.path.join(package_dir, 'resource', 'tiago_webots.urdf')).read_text()
+    robot_description_path = os.path.join(package_dir, 'resource', 'tiago_webots.urdf')
     ros2_control_params = os.path.join(package_dir, 'resource', 'ros2_control.yml')
     nav2_params = os.path.join(package_dir, 'resource', 'nav2_params.yaml')
     toolbox_params = os.path.join(package_dir, 'resource', 'slam_toolbox_params.yaml')
@@ -60,7 +59,7 @@ def get_ros2_nodes(*args):
     tiago_driver = WebotsController(
         robot_name='Tiago_Lite',
         parameters=[
-            {'robot_description': robot_description,
+            {'robot_description': robot_description_path,
              'use_sim_time': use_sim_time,
              'set_robot_state_publisher': True},
             ros2_control_params

--- a/webots_ros2_tiago/launch/robot_launch.py
+++ b/webots_ros2_tiago/launch/robot_launch.py
@@ -28,7 +28,7 @@ from ament_index_python.packages import get_package_share_directory, get_package
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.actions import IncludeLaunchDescription
 from webots_ros2_driver.webots_launcher import WebotsLauncher
-from webots_ros2_driver.utils import controller_url_prefix
+from webots_ros2_driver.webots_controller import WebotsController
 
 
 def launch_spawners(event, nodes):
@@ -57,11 +57,8 @@ def get_ros2_nodes(*args):
     if 'ROS_DISTRO' in os.environ and os.environ['ROS_DISTRO'] in ['humble', 'rolling']:
         mappings.append(('/diffdrive_controller/odom', '/odom'))
 
-    tiago_driver = Node(
-        package='webots_ros2_driver',
-        executable='driver',
-        output='screen',
-        additional_env={'WEBOTS_CONTROLLER_URL': controller_url_prefix() + 'Tiago_Lite'},
+    tiago_driver = WebotsController(
+        robot_name='Tiago_Lite',
         parameters=[
             {'robot_description': robot_description,
              'use_sim_time': use_sim_time,

--- a/webots_ros2_turtlebot/CHANGELOG.rst
+++ b/webots_ros2_turtlebot/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package webots_ros2_turtlebot
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2023.1.0 (2023-XX-XX)
+------------------
+* Update driver node to new WebotsController node.
+
 2023.0.4 (2023-XX-XX)
 ------------------
 * Start ros control and navigation nodes when Webots is ready.

--- a/webots_ros2_turtlebot/launch/robot_launch.py
+++ b/webots_ros2_turtlebot/launch/robot_launch.py
@@ -17,7 +17,6 @@
 """Launch Webots TurtleBot3 Burger driver."""
 
 import os
-import pathlib
 from launch.substitutions import LaunchConfiguration
 from launch.actions import DeclareLaunchArgument
 from launch.substitutions.path_join_substitution import PathJoinSubstitution
@@ -35,7 +34,7 @@ def get_ros2_nodes(*args):
     package_dir = get_package_share_directory('webots_ros2_turtlebot')
     use_nav = LaunchConfiguration('nav', default=False)
     use_slam = LaunchConfiguration('slam', default=False)
-    robot_description = pathlib.Path(os.path.join(package_dir, 'resource', 'turtlebot_webots.urdf')).read_text()
+    robot_description_path = os.path.join(package_dir, 'resource', 'turtlebot_webots.urdf')
     ros2_control_params = os.path.join(package_dir, 'resource', 'ros2control.yml')
     nav2_params = os.path.join(package_dir, 'resource', 'nav2_params.yaml')
     nav2_map = os.path.join(package_dir, 'resource', 'turtlebot3_burger_example_map.yaml')
@@ -70,7 +69,7 @@ def get_ros2_nodes(*args):
     turtlebot_driver = WebotsController(
         robot_name='TurtleBot3Burger',
         parameters=[
-            {'robot_description': robot_description,
+            {'robot_description': robot_description_path,
              'use_sim_time': use_sim_time,
              'set_robot_state_publisher': True},
             ros2_control_params

--- a/webots_ros2_turtlebot/launch/robot_launch.py
+++ b/webots_ros2_turtlebot/launch/robot_launch.py
@@ -28,7 +28,7 @@ from ament_index_python.packages import get_package_share_directory, get_package
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.actions import IncludeLaunchDescription
 from webots_ros2_driver.webots_launcher import WebotsLauncher
-from webots_ros2_driver.utils import controller_url_prefix
+from webots_ros2_driver.webots_controller import WebotsController
 
 
 def get_ros2_nodes(*args):
@@ -67,11 +67,8 @@ def get_ros2_nodes(*args):
     if 'ROS_DISTRO' in os.environ and os.environ['ROS_DISTRO'] in ['humble', 'rolling']:
         mappings.append(('/diffdrive_controller/odom', '/odom'))
 
-    turtlebot_driver = Node(
-        package='webots_ros2_driver',
-        executable='driver',
-        output='screen',
-        additional_env={'WEBOTS_CONTROLLER_URL': controller_url_prefix() + 'TurtleBot3Burger'},
+    turtlebot_driver = WebotsController(
+        robot_name='TurtleBot3Burger',
         parameters=[
             {'robot_description': robot_description,
              'use_sim_time': use_sim_time,

--- a/webots_ros2_universal_robot/CHANGELOG.rst
+++ b/webots_ros2_universal_robot/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package webots_ros2_universal_robot
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2023.1.0 (2023-XX-XX)
+------------------
+* Update driver node to new WebotsController node.
+
 2023.0.4 (2023-XX-XX)
 ------------------
 * Start ros control nodes when Webots is ready.

--- a/webots_ros2_universal_robot/launch/multirobot_launch.py
+++ b/webots_ros2_universal_robot/launch/multirobot_launch.py
@@ -28,7 +28,7 @@ from launch.substitutions.path_join_substitution import PathJoinSubstitution
 from launch_ros.actions import Node
 from webots_ros2_driver.urdf_spawner import URDFSpawner, get_webots_driver_node
 from webots_ros2_driver.webots_launcher import WebotsLauncher
-from webots_ros2_driver.utils import controller_url_prefix
+from webots_ros2_driver.webots_controller import WebotsController
 
 
 PACKAGE_NAME = 'webots_ros2_universal_robot'
@@ -56,16 +56,9 @@ def get_ros2_nodes(*args):
     )
 
     # Driver nodes
-    # When having multiple robot it is enough to specify the `additional_env` argument.
-    # The `WEBOTS_CONTROLLER_URL` has to match the robot name in the world file.
-    # You can check for more information at:
-    # https://cyberbotics.com/doc/guide/running-extern-robot-controllers#single-simulation-and-multiple-extern-robot-controllers
-    ur5e_driver = Node(
-        package='webots_ros2_driver',
-        executable='driver',
-        output='screen',
-        additional_env={'WEBOTS_CONTROLLER_URL': controller_url_prefix() + 'UR5e'},
-        namespace='ur5e',
+    # When having multiple robot it is mandatory to specify the robot name.
+    ur5e_driver = WebotsController(
+        robot_name='UR5e',
         parameters=[
             {'robot_description': ur5e_description},
             {'use_sim_time': True},
@@ -74,12 +67,8 @@ def get_ros2_nodes(*args):
     )
 
     # Standard Webots robot using driver node
-    abb_driver = Node(
-        package='webots_ros2_driver',
-        executable='driver',
-        output='screen',
-        additional_env={'WEBOTS_CONTROLLER_URL': controller_url_prefix() + 'abbirb4600'},
-        namespace='abb',
+    abb_driver = WebotsController(
+        robot_name='abbirb4600',
         parameters=[
             {'robot_description': abb_description},
             {'use_sim_time': True},

--- a/webots_ros2_universal_robot/launch/multirobot_launch.py
+++ b/webots_ros2_universal_robot/launch/multirobot_launch.py
@@ -28,7 +28,6 @@ from launch_ros.actions import Node
 from webots_ros2_driver.urdf_spawner import URDFSpawner, get_webots_driver_node
 from webots_ros2_driver.webots_launcher import WebotsLauncher
 from webots_ros2_driver.webots_controller import WebotsController
-from webots_ros2_driver.utils import controller_url_prefix
 
 
 PACKAGE_NAME = 'webots_ros2_universal_robot'

--- a/webots_ros2_universal_robot/launch/robot_launch/robot_nodes_launch.py
+++ b/webots_ros2_universal_robot/launch/robot_launch/robot_nodes_launch.py
@@ -17,7 +17,6 @@
 """Launch Webots Universal Robot simulation nodes."""
 
 import os
-import pathlib
 import launch
 from launch_ros.actions import Node
 from launch import LaunchDescription
@@ -31,16 +30,15 @@ PACKAGE_NAME = 'webots_ros2_universal_robot'
 
 def generate_launch_description():
     package_dir = get_package_share_directory(PACKAGE_NAME)
-    ur5e_urdf_path = os.path.join(package_dir, 'resource', 'ur5e_with_gripper.urdf')
-    robot_description = pathlib.Path(ur5e_urdf_path).read_text()
+    robot_description_path = os.path.join(package_dir, 'resource', 'ur5e_with_gripper.urdf')
     ros2_control_params = os.path.join(package_dir, 'resource', 'ros2_control_config.yaml')
 
     # Define your URDF robots here
-    # The name of an URDF robot has to match the WEBOTS_CONTROLLER_URL of the driver node
+    # The name of an URDF robot has to match the name of the robot of the driver node
     # You can specify the URDF file to use with "urdf_path"
     spawn_URDF_ur5e = URDFSpawner(
         name='UR5e',
-        urdf_path=ur5e_urdf_path,
+        urdf_path=robot_description_path,
         translation='0 0 0.6',
         rotation='0 0 1 -1.5708',
     )
@@ -50,8 +48,9 @@ def generate_launch_description():
     universal_robot_driver = WebotsController(
         robot_name='UR5e',
         parameters=[
-            {'robot_description': robot_description},
+            {'robot_description': robot_description_path},
             {'use_sim_time': True},
+            {'set_robot_state_publisher': True},
             ros2_control_params
         ]
     )
@@ -83,7 +82,7 @@ def generate_launch_description():
         executable='robot_state_publisher',
         output='screen',
         parameters=[{
-            'robot_description': robot_description
+            'robot_description': '<robot name=""><link name=""/></robot>'
         }],
     )
 

--- a/webots_ros2_universal_robot/launch/robot_launch/robot_nodes_launch.py
+++ b/webots_ros2_universal_robot/launch/robot_launch/robot_nodes_launch.py
@@ -23,7 +23,7 @@ from launch_ros.actions import Node
 from launch import LaunchDescription
 from ament_index_python.packages import get_package_share_directory
 from webots_ros2_driver.urdf_spawner import URDFSpawner, get_webots_driver_node
-from webots_ros2_driver.utils import controller_url_prefix
+from webots_ros2_driver.webots_controller import WebotsController
 
 
 PACKAGE_NAME = 'webots_ros2_universal_robot'
@@ -46,20 +46,14 @@ def generate_launch_description():
     )
 
     # Driver nodes
-    # When having multiple robot it is enough to specify the `additional_env` argument.
-    # The `WEBOTS_CONTROLLER_URL` has to match the robot name in the world file.
-    # You can check for more information at:
-    # https://cyberbotics.com/doc/guide/running-extern-robot-controllers#single-simulation-and-multiple-extern-robot-controllers
-    universal_robot_driver = Node(
-        package='webots_ros2_driver',
-        executable='driver',
-        output='screen',
-        additional_env={'WEBOTS_CONTROLLER_URL': controller_url_prefix() + 'UR5e'},
+    # When having multiple robot it is mandatory to specify the robot name.
+    universal_robot_driver = WebotsController(
+        robot_name='UR5e',
         parameters=[
             {'robot_description': robot_description},
             {'use_sim_time': True},
             ros2_control_params
-        ],
+        ]
     )
 
     # Other ROS 2 nodes


### PR DESCRIPTION
New WebotsController node that starts the webots-controller launcher to setup the correct environment variables and start the Driver interface node.

- [x] Implement the new `WebotsController` ROS 2 node (`ExecuteProcess` type) that is responsible to gather all information about the controller (robot name, port, parameters, etc.) and start the `webots-controller` launcher.
- [x] Update the Driver node to open and read URDF and Xacro files.
- [x] Install the `webots-controller` launcher in the package.
- [x] Update all examples.