### PR TITLE
Fix ros2 control hardware interface API update

### DIFF
--- a/webots_ros2/CHANGELOG.rst
+++ b/webots_ros2/CHANGELOG.rst
@@ -14,7 +14,8 @@ Changelog for package webots_ros2
 * Default to canonical topic name and fix camera_info stamp in Ros2Camera, Ros2RangeFinder.
 * Added VacuumGripper gripper support in webots_ros2_driver.
 * Added BoolStamped message in webots_ros2_msgs.
-* Added GetBool message in webots_ros2_msgs.
+* Added GetBool service in webots_ros2_msgs.
+* Fixed webots_ros2_control component activation.
 
 2023.0.4 (2023-05-23)
 ------------------

--- a/webots_ros2_control/CHANGELOG.rst
+++ b/webots_ros2_control/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package webots_ros2_control
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2023.1.0 (2023-XX-XX)
+------------------
+* Fixed component activation.
+
 2023.0.0 (2022-11-30)
 ------------------
 * Convert C++ controller API functions to C

--- a/webots_ros2_control/src/Ros2Control.cpp
+++ b/webots_ros2_control/src/Ros2Control.cpp
@@ -23,6 +23,8 @@
 #include "hardware_interface/component_parser.hpp"
 #include "hardware_interface/resource_manager.hpp"
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
+#include "hardware_interface/types/lifecycle_state_names.hpp"
+#include "lifecycle_msgs/msg/state.hpp"
 #include "pluginlib/class_list_macros.hpp"
 #include "rclcpp/rclcpp.hpp"
 
@@ -88,7 +90,10 @@ namespace webots_ros2_control {
       webotsSystem->init(mNode, controlHardware[i]);
       resourceManager->import_component(std::move(webotsSystem), controlHardware[i]);
 
-      resourceManager->activate_all_components();
+      // Configure and activate all components
+      using lifecycle_msgs::msg::State;
+      rclcpp_lifecycle::State active_state(State::PRIMARY_STATE_ACTIVE, hardware_interface::lifecycle_state_names::ACTIVE);
+      resourceManager->set_component_state(controlHardware[i].name, active_state);
     }
 
     // Controller Manager

--- a/webots_ros2_control/src/Ros2Control.cpp
+++ b/webots_ros2_control/src/Ros2Control.cpp
@@ -90,10 +90,16 @@ namespace webots_ros2_control {
       webotsSystem->init(mNode, controlHardware[i]);
       resourceManager->import_component(std::move(webotsSystem), controlHardware[i]);
 
-      // Configure and activate all components
+// Configure and activate all components
+// Necessary hotfix for deprecation of component activation present in "hardware_interface" package for versions above 3.15
+// (#793)
+#if HARDWARE_INTERFACE_VERSION_MAJOR >= 3 && HARDWARE_INTERFACE_VERSION_MINOR >= 15
       using lifecycle_msgs::msg::State;
       rclcpp_lifecycle::State active_state(State::PRIMARY_STATE_ACTIVE, hardware_interface::lifecycle_state_names::ACTIVE);
       resourceManager->set_component_state(controlHardware[i].name, active_state);
+#else
+      resourceManager->activate_all_components();
+#endif
     }
 
     // Controller Manager


### PR DESCRIPTION
The activation of all components has been deprecated from version 3.15.0 of hardware_interface. It is replaced by manual activation.

This was reported in https://github.com/ros/rosdistro/pull/37344#issuecomment-1609109208.