### PR TITLE
also check pointcloud subscription count for shouldBeEnabled

### DIFF
--- a/webots_ros2_driver/src/plugins/static/Ros2RangeFinder.cpp
+++ b/webots_ros2_driver/src/plugins/static/Ros2RangeFinder.cpp
@@ -109,7 +109,8 @@ namespace webots_ros2_driver {
       return;
 
     // Enable/Disable sensor
-    const bool shouldBeEnabled = mImagePublisher->get_subscription_count() > 0;
+    const bool shouldBeEnabled =
+      mImagePublisher->get_subscription_count() > 0 || mPointCloudPublisher->get_subscription_count() > 0;
     if (shouldBeEnabled != mIsEnabled) {
       if (shouldBeEnabled)
         wb_range_finder_enable(mRangeFinder, mPublishTimestepSyncedMs);


### PR DESCRIPTION
I noticed that the RangeFinder only publishes point clouds when there is at least one subscriber to its depth image topic. This PR simply also checks the number of point cloud subscribers.