### PR TITLE
Fix backwards compatibility with driver node

### DIFF
--- a/webots_ros2_driver/CHANGELOG.rst
+++ b/webots_ros2_driver/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package webots_ros2_driver
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2023.1.1 (2023-XX-XX)
+------------------
+* Added deprecation message when declaring driver node in launch file.
+
 2023.1.0 (2023-06-29)
 ------------------
 * Added Ros2Pen static plugin.

--- a/webots_ros2_driver/CMakeLists.txt
+++ b/webots_ros2_driver/CMakeLists.txt
@@ -77,6 +77,7 @@ ament_python_install_package(${PROJECT_NAME}
   PACKAGE_DIR ${PROJECT_NAME})
 
 # Driver
+set(CMAKE_INSTALL_RPATH "$ORIGIN/../controller") # Deprecated with new WebotsController node, remove with 2024.0.0
 add_executable(driver
   src/Driver.cpp
   src/WebotsNode.cpp
@@ -126,6 +127,7 @@ install(TARGETS driver
 )
 
 # Dynamic IMU
+set(CMAKE_INSTALL_RPATH "$ORIGIN/controller") # Deprecated with new WebotsController node, remove with 2024.0.0
 add_library(
   ${PROJECT_NAME}_imu
   SHARED
@@ -153,6 +155,7 @@ install(TARGETS ${PROJECT_NAME}_imu
 )
 
 # Dynamic RGBD
+set(CMAKE_INSTALL_RPATH "$ORIGIN/controller") # Deprecated with new WebotsController node, remove with 2024.0.0
 add_library(
   ${PROJECT_NAME}_rgbd
   SHARED


### PR DESCRIPTION
Fixes #796 (partially).

Since 2023.1.0, it is not possible to declare the driver node in the launch file anymore. Instead the WebotsController should be used instead. This PR restores backwards compatibility and a deprecation message when using the old way.

