### PR TITLE
Add animation recording services

### DIFF
--- a/webots_ros2_driver/webots_ros2_driver/ros2_supervisor.py
+++ b/webots_ros2_driver/webots_ros2_driver/ros2_supervisor.py
@@ -37,7 +37,7 @@ from std_msgs.msg import String
 from webots_ros2_driver.utils import is_wsl, has_shared_folder, container_shared_folder, host_shared_folder
 sys.path.insert(1, os.path.join(os.path.dirname(webots_ros2_importer.__file__), 'urdf2webots'))
 from urdf2webots.importer import convertUrdfFile, convertUrdfContent  # noqa
-from webots_ros2_msgs.srv import SpawnUrdfRobot, SpawnNodeFromString  # noqa
+from webots_ros2_msgs.srv import GetBool, SetString, SpawnUrdfRobot, SpawnNodeFromString # noqa
 
 # As Ros2Supervisor needs the controller library, we extend the path here
 # to avoid to load another library named "controller" or "vehicle".
@@ -65,6 +65,9 @@ class Ros2Supervisor(Node):
         # Services
         self.create_service(SpawnUrdfRobot, 'spawn_urdf_robot', self.__spawn_urdf_robot_callback)
         self.create_service(SpawnNodeFromString, 'spawn_node_from_string', self.__spawn_node_from_string_callback)
+        self.create_service(SetString, 'animation_start_recording', self.__animation_start_recording_callback)
+        self.create_service(GetBool, 'animation_stop_recording', self.__animation_stop_recording_callback)
+
         # Subscriptions
         self.create_subscription(String, 'remove_node', self.__remove_imported_node_callback, qos_profile_services_default)
 
@@ -218,6 +221,17 @@ class Ros2Supervisor(Node):
 
         self.get_logger().info('Ros2Supervisor has imported the node named "' + str(object_name) + '".')
         response.success = True
+        return response
+
+    def __animation_start_recording_callback(self, request: SetString.Request, response: SetString.Response):
+        filename = request.value
+        self.get_logger().info(f"Start recording animation to {filename}")
+        response.success = self.__robot.animationStartRecording(filename)
+        return response
+
+    def __animation_stop_recording_callback(self, request: GetBool.Request, response: GetBool.Response):
+        self.get_logger().info(f"Stop recording animation")
+        response.value = self.__robot.animationStopRecording()
         return response
 
     # Allows to remove any imported node (urdf robots / VRML Nodes) by name.

--- a/webots_ros2_msgs/CMakeLists.txt
+++ b/webots_ros2_msgs/CMakeLists.txt
@@ -32,10 +32,11 @@ set(msg_files
   "msg/PenInkProperties.msg"
 )
 set(srv_files
-  "srv/GetBool.srv"
   "srv/EmitterSendString.srv"
-  "srv/SpawnUrdfRobot.srv"
+  "srv/GetBool.srv"
+  "srv/SetString.srv"
   "srv/SpawnNodeFromString.srv"
+  "srv/SpawnUrdfRobot.srv"
 )
 
 rosidl_generate_interfaces(${PROJECT_NAME}

--- a/webots_ros2_msgs/srv/SetString.srv
+++ b/webots_ros2_msgs/srv/SetString.srv
@@ -1,0 +1,3 @@
+string value
+---
+bool success


### PR DESCRIPTION
**Description**
Adds the `animation_start_recording` and `animation_stop_recording` services as documented in the [webots documentation](https://cyberbotics.com/doc/reference/supervisor?tab-language=ros#wb_supervisor_animation_start_recording) (for ROS 1).

**Related Issues**
This pull-request fixes issue #809 

**Affected Packages**
List of affected packages:
  - webots_ros2_driver
  - webots_ros2_msgs

**Tasks**
  - [x] Implementation
  - [ ] Documentation ?
  - [ ] Update Changelog

**Additional context**

