### PR TITLE
Deprecate URDF Spawner

### DIFF
--- a/webots_ros2_driver/webots_ros2_driver/ros2_supervisor.py
+++ b/webots_ros2_driver/webots_ros2_driver/ros2_supervisor.py
@@ -69,6 +69,7 @@ class Ros2Supervisor(Node):
         self.create_subscription(String, 'remove_node', self.__remove_imported_node_callback, qos_profile_services_default)
 
     def __spawn_urdf_robot_callback(self, request, response):
+        self.get_logger().warn('\033[33mThe URDF Spawner is deprecated. Please use the PROTO Spawner instead.\033[0m')  # Deprecated, remove in 2024.0.0
         robot = request.robot
 
         robot_name = robot.name if robot.name else ''

--- a/webots_ros2_driver/webots_ros2_driver/ros2_supervisor.py
+++ b/webots_ros2_driver/webots_ros2_driver/ros2_supervisor.py
@@ -69,7 +69,8 @@ class Ros2Supervisor(Node):
         self.create_subscription(String, 'remove_node', self.__remove_imported_node_callback, qos_profile_services_default)
 
     def __spawn_urdf_robot_callback(self, request, response):
-        self.get_logger().warn('\033[33mThe URDF Spawner is deprecated. Please use the PROTO Spawner instead.\033[0m')  # Deprecated, remove in 2024.0.0
+        # Deprecated, remove in 2024.0.0
+        self.get_logger().warn('\033[33mThe URDF Spawner is deprecated. Please use the PROTO Spawner instead.\033[0m')
         robot = request.robot
 
         robot_name = robot.name if robot.name else ''

--- a/webots_ros2_driver/webots_ros2_driver/urdf_spawner.py
+++ b/webots_ros2_driver/webots_ros2_driver/urdf_spawner.py
@@ -27,8 +27,8 @@ def get_webots_driver_node(event, driver_node):
         print('WARNING: the Ros2Supervisor was not able to spawn this URDF robot.')
     return
 
-# Deprecated, remove in 2024.0.0
-class URDFSpawner(ExecuteProcess):
+
+class URDFSpawner(ExecuteProcess): # Deprecated, remove in 2024.0.0
     def __init__(self, output='log', name=None, urdf_path=None, robot_description=None, relative_path_prefix=None,
                  translation='0 0 0', rotation='0 0 1 0', normal=False, box_collision=False, init_pos=None, **kwargs):
         message = '{robot: {'

--- a/webots_ros2_driver/webots_ros2_driver/urdf_spawner.py
+++ b/webots_ros2_driver/webots_ros2_driver/urdf_spawner.py
@@ -28,7 +28,7 @@ def get_webots_driver_node(event, driver_node):
     return
 
 
-class URDFSpawner(ExecuteProcess): # Deprecated, remove in 2024.0.0
+class URDFSpawner(ExecuteProcess):  # Deprecated, remove in 2024.0.0
     def __init__(self, output='log', name=None, urdf_path=None, robot_description=None, relative_path_prefix=None,
                  translation='0 0 0', rotation='0 0 1 0', normal=False, box_collision=False, init_pos=None, **kwargs):
         message = '{robot: {'

--- a/webots_ros2_driver/webots_ros2_driver/urdf_spawner.py
+++ b/webots_ros2_driver/webots_ros2_driver/urdf_spawner.py
@@ -27,7 +27,7 @@ def get_webots_driver_node(event, driver_node):
         print('WARNING: the Ros2Supervisor was not able to spawn this URDF robot.')
     return
 
-
+# Deprecated, remove in 2024.0.0
 class URDFSpawner(ExecuteProcess):
     def __init__(self, output='log', name=None, urdf_path=None, robot_description=None, relative_path_prefix=None,
                  translation='0 0 0', rotation='0 0 1 0', normal=False, box_collision=False, init_pos=None, **kwargs):


### PR DESCRIPTION
For a clearer robot format support, the URDF/Xacro format is now deprecated and will no longer be supported. Instead, robots must be declared directly as PROTO files in the world file. They can still be imported on the fly using the robot string importer and the Ros2Supervisor.

Projects using URDF/Xacro robots can be converted manually to PROTO using the urdf2webots converter.

A new PROTO Spawner will be implemented in the develop branch.