### PR TITLE
Update default planning configs to use AddTimeOptimalParameterization

### DIFF
--- a/webots_ros2_universal_robot/resource/moveit_movegroup.yaml
+++ b/webots_ros2_universal_robot/resource/moveit_movegroup.yaml
@@ -1,9 +1,8 @@
 planning_plugin: ompl_interface/OMPLPlanner
 request_adapters:
-  default_planner_request_adapters/AddTimeParameterization
+  default_planner_request_adapters/AddTimeOptimalParameterization
   default_planner_request_adapters/ResolveConstraintFrames
   default_planner_request_adapters/FixWorkspaceBounds
   default_planner_request_adapters/FixStartStateBounds
   default_planner_request_adapters/FixStartStateCollision
   default_planner_request_adapters/FixStartStatePathConstraints
-  default_planner_request_adapters/AddTimeParameterization


### PR DESCRIPTION
referring https://github.com/ros-planning/moveit2/pull/2167

**Description**
AddTimeOptimalParameterization instead of AddTimeParameterization because the latter was deleted in [this PR](https://github.com/ros-planning/moveit2/commit/62e6f9e718ecd849b3e88c3654b58687d2865097#diff-bdef0ee1a8e9c464c8d88ca8b4bbc9146d82809967d12357782009bead81ab0f).

**Affected Packages**
List of affected packages:
  - webots_ros2_universal_robot
