### PR TITLE
add remappings to robot state publisher for ur5e example

### DIFF
--- a/webots_ros2_driver/src/WebotsNode.cpp
+++ b/webots_ros2_driver/src/WebotsNode.cpp
@@ -306,7 +306,7 @@ namespace webots_ros2_driver {
   }
 
   void WebotsNode::setAnotherNodeParameter(std::string anotherNodeName, std::string parameterName, std::string parameterValue) {
-    mClient = create_client<rcl_interfaces::srv::SetParameters>(get_namespace() + anotherNodeName + "/set_parameters");
+    mClient = create_client<rcl_interfaces::srv::SetParameters>(anotherNodeName + "/set_parameters");
     mClient->wait_for_service(std::chrono::seconds(1));
     rcl_interfaces::srv::SetParameters::Request::SharedPtr request =
       std::make_shared<rcl_interfaces::srv::SetParameters::Request>();

--- a/webots_ros2_universal_robot/launch/robot_launch/robot_moveit_nodes_launch.py
+++ b/webots_ros2_universal_robot/launch/robot_launch/robot_moveit_nodes_launch.py
@@ -41,6 +41,13 @@ def generate_launch_description():
 
     # Check if moveit is installed
     if 'moveit' in get_packages_with_prefixes():
+        # Webots simulation with robot
+        launch_description_nodes.append(
+            IncludeLaunchDescription(
+                PythonLaunchDescriptionSource(os.path.join(package_dir, 'launch', 'robot_nodes_launch.py'))
+            )
+        )
+
         # Configuration
         description = {'robot_description': load_file('ur5e_with_gripper.urdf')}
         description_semantic = {'robot_description_semantic': load_file('moveit_ur5e.srdf')}
@@ -85,14 +92,7 @@ def generate_launch_description():
                     movegroup,
                     sim_time
                 ],
-                remappings=[('/joint_states', '/ur5e/joint_states')]
-            )
-        )
-
-        # Webots simulation with robot
-        launch_description_nodes.append(
-            IncludeLaunchDescription(
-                PythonLaunchDescriptionSource(os.path.join(package_dir, 'launch', 'robot_nodes_launch.py'))
+                remappings=[('/joint_states', '/ur5e/joint_states')],
             )
         )
     else:

--- a/webots_ros2_universal_robot/launch/robot_launch/robot_moveit_nodes_launch.py
+++ b/webots_ros2_universal_robot/launch/robot_launch/robot_moveit_nodes_launch.py
@@ -92,7 +92,7 @@ def generate_launch_description():
                     movegroup,
                     sim_time
                 ],
-                remappings=[('/joint_states', '/ur5e/joint_states')],
+                remappings=[('/joint_states', '/ur5e/joint_states')]
             )
         )
     else:

--- a/webots_ros2_universal_robot/launch/robot_launch/robot_nodes_launch.py
+++ b/webots_ros2_universal_robot/launch/robot_launch/robot_nodes_launch.py
@@ -47,13 +47,13 @@ def generate_launch_description():
     # When having multiple robot it is mandatory to specify the robot name.
     universal_robot_driver = WebotsController(
         robot_name='UR5e',
+        namespace='ur5e',
         parameters=[
             {'robot_description': robot_description_path},
             {'use_sim_time': True},
             {'set_robot_state_publisher': True},
             ros2_control_params
         ],
-        namespace='ur5e'
     )
 
     # Other ROS 2 nodes
@@ -77,15 +77,12 @@ def generate_launch_description():
 
     robot_state_publisher = Node(
         package='robot_state_publisher',
+        namespace='ur5e',
         executable='robot_state_publisher',
         output='screen',
         parameters=[{
             'robot_description': '<robot name=""><link name=""/></robot>'
         }],
-        remappings=[
-            ('/joint_states', '/ur5e/joint_states'),
-            ('/robot_state_publisher/set_parameters', '/ur5erobot_state_publisher/set_parameters'),
-        ],
     )
 
     return LaunchDescription([

--- a/webots_ros2_universal_robot/launch/robot_launch/robot_nodes_launch.py
+++ b/webots_ros2_universal_robot/launch/robot_launch/robot_nodes_launch.py
@@ -82,6 +82,10 @@ def generate_launch_description():
         parameters=[{
             'robot_description': '<robot name=""><link name=""/></robot>'
         }],
+        remappings=[
+            ('/joint_states', '/ur5e/joint_states'),
+            ('/robot_state_publisher/set_parameters', '/ur5erobot_state_publisher/set_parameters'),
+        ],
     )
 
     return LaunchDescription([


### PR DESCRIPTION
follow up to https://github.com/cyberbotics/webots_ros2/commit/f3045ad16c6c41b0edbf845f06391be5d0990022

**Description**
robot state publisher's robot_description update service doesn't get called, and also doesn't subscribe to joint_states' topic, because of the namespace 'ur5e' added to the WebotsController
add remappings to the robot state publisher node to fix it

**Affected Packages**
List of affected packages:
  - webots_ros2_universal_robot