### PR TITLE
Compatibility for Docker on macOS

### DIFF
--- a/webots_ros2_driver/scripts/webots_tcp_client.py
+++ b/webots_ros2_driver/scripts/webots_tcp_client.py
@@ -35,26 +35,30 @@ def get_host_ip():
         sys.exit('Unable to get host IP address. \'ip route\' could not be executed.')
 
 
-HOST = get_host_ip()  # Connect to host of the VM
-PORT = 2000  # Port to connect to
-
-tcp_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-launch_arguments = ''
-for arg in sys.argv:
-    if arg.endswith('.py') or arg == '':
-        continue
-    elif arg.endswith('.wbt'):
-        world_name = arg
-    else:
-        launch_arguments = launch_arguments + ' ' + arg
-
-
 def host_shared_folder():
     shared_folder_list = os.environ['WEBOTS_SHARED_FOLDER'].split(':')
     return shared_folder_list[0]
 
 
-while tcp_socket.connect_ex((HOST, PORT)) != 0:
+host_ip = None
+host_port = None
+
+launch_arguments = ''
+for arg in sys.argv[1:]:
+    if arg.endswith('.wbt'):
+        world_name = arg
+    elif "--host_ip=" in arg:
+        host_ip = arg.replace("--host_ip=", "")
+    elif "--host_port=" in arg:
+        host_port = int(arg.replace("--host_port=", ""))
+    else:
+        launch_arguments = launch_arguments + ' ' + arg
+
+host_ip = get_host_ip() if host_ip is None else host_ip
+host_port = 2000 if host_port is None else host_port
+
+tcp_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+while tcp_socket.connect_ex((host_ip, host_port)) != 0:
     print('WARNING: Unable to start Webots. Please start the local simulation server on your host machine. Next connection '
           'attempt in 1 second.', file=sys.stderr)
     time.sleep(1)

--- a/webots_ros2_driver/scripts/webots_tcp_client.py
+++ b/webots_ros2_driver/scripts/webots_tcp_client.py
@@ -32,7 +32,7 @@ def get_host_ip():
                 return fields[2]
         sys.exit('Unable to get host IP address.')
     except subprocess.CalledProcessError:
-        sys.exit('Unable to get host IP address. \'ip route\' could not be executed.')
+        sys.exit('Unable to get host IP address. \'ip route\' could not be executed. Make sure that iproute2 is installed.')
 
 
 def host_shared_folder():

--- a/webots_ros2_driver/webots_ros2_driver/utils.py
+++ b/webots_ros2_driver/webots_ros2_driver/utils.py
@@ -132,7 +132,7 @@ def get_host_ip():
                 return fields[2]
         sys.exit('Unable to get host IP address.')
     except subprocess.CalledProcessError:
-        sys.exit('Unable to get host IP address. \'ip route\' could not be executed.')
+        sys.exit('Unable to get host IP address. \'ip route\' could not be executed. Make sure that iproute2 is installed.')
 
 
 def controller_protocol():

--- a/webots_ros2_driver/webots_ros2_driver/webots_controller.py
+++ b/webots_ros2_driver/webots_ros2_driver/webots_controller.py
@@ -29,11 +29,11 @@ from webots_ros2_driver.utils import controller_protocol, controller_ip_address
 
 class WebotsController(ExecuteProcess):
     def __init__(self, output='screen', respawn=False, remappings=[],
-                 namespace='', parameters=[], robot_name='', port='1234', **kwargs):
+                 namespace='', parameters=[], robot_name='', ip_address='', port='1234', **kwargs):
         webots_controller = (os.path.join(get_package_share_directory('webots_ros2_driver'), 'scripts', 'webots-controller'))
 
         protocol = controller_protocol()
-        ip_address = controller_ip_address() if (protocol == 'tcp') else ''
+        ip_address = controller_ip_address() if (ip_address == '' and protocol == 'tcp') else ip_address
 
         robot_name_option = [] if not robot_name else ['--robot-name=' + robot_name]
         ip_address_option = [] if not ip_address else ['--ip-address=' + ip_address]

--- a/webots_ros2_driver/webots_ros2_driver/webots_launcher.py
+++ b/webots_ros2_driver/webots_ros2_driver/webots_launcher.py
@@ -54,7 +54,7 @@ class _ConditionalSubstitution(Substitution):
 
 class WebotsLauncher(ExecuteProcess):
     def __init__(self, output='screen', world=None, gui=True, mode='realtime', stream=False, ros2_supervisor=False,
-                 port='1234', **kwargs):
+                 port='1234', host_ip=None, host_port=2000, **kwargs):
         if sys.platform == 'win32':
             print('WARNING: Native webots_ros2 compatibility with Windows is deprecated and will be removed soon. Please use a '
                   'WSL (Windows Subsystem for Linux) environment instead.', file=sys.stderr)
@@ -100,6 +100,14 @@ class WebotsLauncher(ExecuteProcess):
             stream_argument = "--stream=" + stream
         port_argument = '--port=' + port
 
+        host_ip_argument = ""
+        if host_ip is not None:
+            host_ip_argument = "--host_ip=" + host_ip
+
+        host_port_argument = ""
+        if host_port is not None:
+            host_port_argument = "--host_port=" + str(host_port)
+
         xvfb_run_prefix = []
 
         if 'WEBOTS_OFFSCREEN' in os.environ:
@@ -138,6 +146,8 @@ class WebotsLauncher(ExecuteProcess):
                     webots_path,
                     stream_argument,
                     port_argument,
+                    host_ip_argument,
+                    host_port_argument,
                     no_rendering,
                     stdout,
                     stderr,


### PR DESCRIPTION
**Description**
Hey, 
I want to use Webots with ROS running in Docker on macOS  and not in the VM since the rest of my project runs in docker anyway.
So I made changes so that you can provide a host ip address in the launch file for WebotsLauncher and WebotsController. If you don't, they will just use the get_host_ip function like before.

```
webots = WebotsLauncher(
        world=PathJoinSubstitution([package_dir, 'worlds', world]),
        host_ip="host.docker.internal",
        ros2_supervisor=False
)
```

```
epuck_driver = WebotsController(
        robot_name='e-puck',
        ip_address="host.docker.internal",
        parameters=[
            {'robot_description': robot_description_path,
             'use_sim_time': use_sim_time,
             'set_robot_state_publisher': True},
            ros2_control_params
        ],
        remappings=mappings,
        respawn=True
    )
```

**Affected Packages**
List of affected packages:
  - webots_ros2_driver