### PR TITLE
Copy forests with world

### DIFF
--- a/webots_ros2_driver/webots_ros2_driver/webots_launcher.py
+++ b/webots_ros2_driver/webots_ros2_driver/webots_launcher.py
@@ -174,6 +174,16 @@ class WebotsLauncher(ExecuteProcess):
             sumonet_copy_path = Path(self.__world_copy.name).with_name(Path(self.__world_copy.name).stem + '_net')
             shutil.copytree(sumonet_path, sumonet_copy_path)
 
+        # Copy forests
+        forests_path = Path(world_path).with_name('forest')
+        if forests_path.exists():
+            forests_copy = Path(self.__world_copy.name).with_name('forest')
+
+            if forests_copy.exists():
+                shutil.rmtree(forests_copy)
+
+            shutil.copytree(forests_path, forests_copy)
+
         # Update relative paths in the world
         with open(self.__world_copy.name, 'r') as file:
             content = file.read()


### PR DESCRIPTION
**Description**
This PR simply copies (and cleans up) forest files relitive to the world when using WebotsLauncher, similar to SUMO files. Previously, these files would not be copied, and forests would be empty. 

This PR is tested as working on Humble with 2023b.

**Related Issues**
This pull-request fixes issue #864 

**Affected Packages**
List of affected packages:
  - webots_ros2_driver
