### PR TITLE
support Mirrored mode networking for wsl2

### DIFF
--- a/webots_ros2_driver/webots_ros2_driver/utils.py
+++ b/webots_ros2_driver/webots_ros2_driver/utils.py
@@ -139,7 +139,8 @@ def get_wsl_ip_address():
     # wsl2 net mode
     # NAT: if get_router_ip() == get_wsl_host_ip()
     # Mirrored: if get_router_ip() != get_wsl_host_ip()
-    return get_wsl_host_ip() if get_router_ip() == get_wsl_host_ip() else '127.0.0.1'
+    wsl_host_ip = get_wsl_host_ip()
+    return wsl_host_ip if get_router_ip() == wsl_host_ip else '127.0.0.1'
 
 
 def controller_protocol():


### PR DESCRIPTION
**Description**
[Mirrored mode networking](https://learn.microsoft.com/en-us/windows/wsl/networking#mirrored-mode-networking) is a new network mode of wsl2. In this mode, we can use localhost accessing Windows networking apps from Linux.

When the following is written in the `.wslconfig` file, the wsl2 is switched to Mirrored mode
```
# Enable experimental features
[experimental]
# Network
networkingMode=mirrored
dnsTunneling=true
firewall=true
autoProxy=true
```
**Related Issues**
maybe [#759](https://github.com/cyberbotics/webots_ros2/issues/759#issuecomment-1878485262)

**Affected Packages**
  - webots_ros2_driver

**Tasks**
Add the list of tasks of this PR.
  - [ ] support Mirrored mode networking for wsl2
  - [ ] rename a few function

**Additional context**

