### PR TITLE
Fix version check for hardware_interface

### DIFF
--- a/webots_ros2_control/src/Ros2Control.cpp
+++ b/webots_ros2_control/src/Ros2Control.cpp
@@ -78,7 +78,7 @@ namespace webots_ros2_control {
     }
     for (unsigned int i = 0; i < controlHardware.size(); i++) {
 // Necessary hotfix for renamed variables present in "hardware_interface" package for versions above 3.5 (#590)
-#if HARDWARE_INTERFACE_VERSION_MAJOR >= 3 && HARDWARE_INTERFACE_VERSION_MINOR >= 5
+#if HARDWARE_INTERFACE_VERSION_MAJOR >= 4 || HARDWARE_INTERFACE_VERSION_MAJOR >= 3 && HARDWARE_INTERFACE_VERSION_MINOR >= 5
       const std::string pluginName = controlHardware[i].hardware_plugin_name;
       auto webotsSystem =
         std::unique_ptr<webots_ros2_control::Ros2ControlSystemInterface>(mHardwareLoader->createUnmanagedInstance(pluginName));
@@ -93,7 +93,7 @@ namespace webots_ros2_control {
 // Configure and activate all components
 // Necessary hotfix for deprecation of component activation present in "hardware_interface" package for versions above 3.15
 // (#793)
-#if HARDWARE_INTERFACE_VERSION_MAJOR >= 3 && HARDWARE_INTERFACE_VERSION_MINOR >= 15
+#if HARDWARE_INTERFACE_VERSION_MAJOR >= 4 || HARDWARE_INTERFACE_VERSION_MAJOR >= 3 && HARDWARE_INTERFACE_VERSION_MINOR >= 15
       using lifecycle_msgs::msg::State;
       rclcpp_lifecycle::State active_state(State::PRIMARY_STATE_ACTIVE, hardware_interface::lifecycle_state_names::ACTIVE);
       resourceManager->set_component_state(controlHardware[i].name, active_state);


### PR DESCRIPTION
Fix #881 

Latest version of `hardware_interface` on Rolling is `4.2.0`