### PR TITLE
Fix host IP address resolution for nodes running in Docker

### DIFF
--- a/webots_ros2_driver/scripts/webots_tcp_client.py
+++ b/webots_ros2_driver/scripts/webots_tcp_client.py
@@ -16,6 +16,7 @@
 
 """TCP client to start Webots on the host."""
 
+from pathlib import Path
 import os
 import socket
 import subprocess
@@ -23,7 +24,15 @@ import sys
 import time
 
 
+def is_docker():
+    mountinfo = Path("/proc/self/mountinfo")
+    return mountinfo.is_file() and "docker" in mountinfo.read_text()
+
+
 def get_host_ip():
+    if is_docker():
+        return "host.docker.internal"
+
     try:
         output = subprocess.run(['ip', 'route'], check=True, stdout=subprocess.PIPE, universal_newlines=True)
         for line in output.stdout.split('\n'):

--- a/webots_ros2_driver/webots_ros2_driver/utils.py
+++ b/webots_ros2_driver/webots_ros2_driver/utils.py
@@ -123,7 +123,15 @@ def container_shared_folder():
     return shared_folder_list[1]
 
 
+def is_docker():
+    mountinfo = Path("/proc/self/mountinfo")
+    return mountinfo.is_file() and "docker" in mountinfo.read_text()
+
+
 def get_host_ip():
+    if is_docker():
+        return "host.docker.internal"
+
     try:
         output = subprocess.run(['ip', 'route'], check=True, stdout=subprocess.PIPE, universal_newlines=True)
         for line in output.stdout.split('\n'):


### PR DESCRIPTION
**Description**

This PR fixes a bug preventing `webots_ros2_driver` nodes running in a Docker image from launching and connecting to Webots running on a macOS host. The change set includes a new `is_docker()` function that checks if the process is running in an image. If so, the `get_host_ip()` will return `host.docker.internal`, [Docker's special DNS name](https://docs.docker.com/desktop/networking/#i-want-to-connect-from-a-container-to-a-service-on-the-host) that resolves to the host's IP address.

**Related Issues**
Closes #888 

**Affected Packages**
List of affected packages:
  - `webots_ros2_driver`

**Tasks**

**Additional context**
I modeled the changes off the `is_wsl()` function; however, WSL has tighter integration with its host (Windows) than Docker Desktop. Docker and virtual machines seem like identical setups as far as this package is concerned.

I am not intimately familiar with the `webots_ros2_driver` package, so feel free to suggest modifications if there are more appropriate places for these changes.