### PR TITLE
Bump version and changelogs to 2023.1.2

### DIFF
--- a/webots_ros2/package.xml
+++ b/webots_ros2/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>webots_ros2</name>
-  <version>2023.1.1</version>
+  <version>2023.1.2</version>
   <description>Interface between Webots and ROS2</description>
 
   <maintainer email="support@cyberbotics.com">Cyberbotics</maintainer>

--- a/webots_ros2/setup.py
+++ b/webots_ros2/setup.py
@@ -6,7 +6,7 @@ package_name = 'webots_ros2'
 
 setup(
     name=package_name,
-    version='2023.1.1',
+    version='2023.1.2',
     packages=[package_name],
     data_files=[
         ('share/' + package_name, ['package.xml']),

--- a/webots_ros2_control/CHANGELOG.rst
+++ b/webots_ros2_control/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog for package webots_ros2_control
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2023.1.2 (2024-02-02)
+------------------
+* Fix host IP address resolution for nodes running in Docker.
+* Fix hardware_interface version check with latest ros2_controls.
+* Copy forests with world.
+* Sync libcontroller master.
+
 2023.1.0 (2023-06-29)
 ------------------
 * Fixed component activation.

--- a/webots_ros2_control/package.xml
+++ b/webots_ros2_control/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>webots_ros2_control</name>
-  <version>2023.1.1</version>
+  <version>2023.1.2</version>
   <description>ros2_control plugin for Webots</description>
   <maintainer email="support@cyberbotics.com">Cyberbotics</maintainer>
   <url type="website">http://wiki.ros.org/webots_ros2</url>

--- a/webots_ros2_driver/package.xml
+++ b/webots_ros2_driver/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>webots_ros2_driver</name>
-  <version>2023.1.1</version>
+  <version>2023.1.2</version>
   <description>Implementation of the Webots - ROS 2 interface</description>
   <maintainer email="support@cyberbotics.com">Cyberbotics</maintainer>
   <license>Apache License 2.0</license>

--- a/webots_ros2_epuck/package.xml
+++ b/webots_ros2_epuck/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>webots_ros2_epuck</name>
-  <version>2023.1.1</version>
+  <version>2023.1.2</version>
   <description>E-puck2 driver for Webots simulated robot</description>
 
   <maintainer email="support@cyberbotics.com">Cyberbotics</maintainer>

--- a/webots_ros2_epuck/setup.py
+++ b/webots_ros2_epuck/setup.py
@@ -43,7 +43,7 @@ data_files.append(('share/' + package_name, [
 
 setup(
     name=package_name,
-    version='2023.1.1',
+    version='2023.1.2',
     packages=[package_name],
     data_files=data_files,
     install_requires=['setuptools', 'launch'],

--- a/webots_ros2_importer/package.xml
+++ b/webots_ros2_importer/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>webots_ros2_importer</name>
-  <version>2023.1.1</version>
+  <version>2023.1.2</version>
   <description>This package allows to convert URDF and XACRO files into Webots PROTO files.</description>
 
   <maintainer email="support@cyberbotics.com">Cyberbotics</maintainer>

--- a/webots_ros2_importer/setup.py
+++ b/webots_ros2_importer/setup.py
@@ -10,7 +10,7 @@ data_files.append(('share/' + package_name, ['package.xml']))
 
 setup(
     name=package_name,
-    version='2023.1.1',
+    version='2023.1.2',
     packages=[package_name, package_name + '.urdf2webots.urdf2webots'],
     data_files=data_files,
     install_requires=[

--- a/webots_ros2_mavic/package.xml
+++ b/webots_ros2_mavic/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>webots_ros2_mavic</name>
-  <version>2023.1.1</version>
+  <version>2023.1.2</version>
   <description>Mavic 2 Pro robot ROS2 interface for Webots.</description>
 
   <maintainer email="support@cyberbotics.com">Cyberbotics</maintainer>

--- a/webots_ros2_mavic/setup.py
+++ b/webots_ros2_mavic/setup.py
@@ -18,7 +18,7 @@ data_files.append(('share/' + package_name, ['package.xml']))
 
 setup(
     name=package_name,
-    version='2023.1.1',
+    version='2023.1.2',
     packages=[package_name],
     data_files=data_files,
     install_requires=['setuptools', 'launch'],

--- a/webots_ros2_msgs/package.xml
+++ b/webots_ros2_msgs/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>webots_ros2_msgs</name>
-  <version>2023.1.1</version>
+  <version>2023.1.2</version>
   <description>Services and Messages of the webots_ros2 packages.</description>
 
   <maintainer email="support@cyberbotics.com">Cyberbotics</maintainer>

--- a/webots_ros2_tesla/package.xml
+++ b/webots_ros2_tesla/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>webots_ros2_tesla</name>
-  <version>2023.1.1</version>
+  <version>2023.1.2</version>
   <description>Tesla ROS2 interface for Webots.</description>
 
   <maintainer email="support@cyberbotics.com">Cyberbotics</maintainer>

--- a/webots_ros2_tesla/setup.py
+++ b/webots_ros2_tesla/setup.py
@@ -18,7 +18,7 @@ data_files.append(('share/' + package_name, ['package.xml']))
 
 setup(
     name=package_name,
-    version='2023.1.1',
+    version='2023.1.2',
     packages=[package_name],
     data_files=data_files,
     install_requires=['setuptools', 'launch'],

--- a/webots_ros2_tests/package.xml
+++ b/webots_ros2_tests/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>webots_ros2_tests</name>
-  <version>2023.1.1</version>
+  <version>2023.1.2</version>
   <description>System tests for `webots_ros2` packages.</description>
 
   <maintainer email="support@cyberbotics.com">Cyberbotics</maintainer>

--- a/webots_ros2_tests/setup.py
+++ b/webots_ros2_tests/setup.py
@@ -11,7 +11,7 @@ data_files = [
 
 setup(
     name=package_name,
-    version='2023.1.1',
+    version='2023.1.2',
     packages=[package_name],
     data_files=data_files,
     install_requires=['setuptools', 'launch'],

--- a/webots_ros2_tiago/package.xml
+++ b/webots_ros2_tiago/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>webots_ros2_tiago</name>
-  <version>2023.1.1</version>
+  <version>2023.1.2</version>
   <description>TIAGo robots ROS2 interface for Webots.</description>
 
   <maintainer email="support@cyberbotics.com">Cyberbotics</maintainer>

--- a/webots_ros2_tiago/setup.py
+++ b/webots_ros2_tiago/setup.py
@@ -32,7 +32,7 @@ data_files.append(('share/' + package_name + '/worlds', [
 
 setup(
     name=package_name,
-    version='2023.1.1',
+    version='2023.1.2',
     packages=[],
     data_files=data_files,
     install_requires=['setuptools', 'launch'],

--- a/webots_ros2_turtlebot/package.xml
+++ b/webots_ros2_turtlebot/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>webots_ros2_turtlebot</name>
-  <version>2023.1.1</version>
+  <version>2023.1.2</version>
   <description>TurtleBot3 Burger robot ROS2 interface for Webots.</description>
 
   <maintainer email="support@cyberbotics.com">Cyberbotics</maintainer>

--- a/webots_ros2_turtlebot/setup.py
+++ b/webots_ros2_turtlebot/setup.py
@@ -23,7 +23,7 @@ data_files.append(('share/' + package_name, ['package.xml']))
 
 setup(
     name=package_name,
-    version='2023.1.1',
+    version='2023.1.2',
     packages=[package_name],
     data_files=data_files,
     install_requires=['setuptools', 'launch'],

--- a/webots_ros2_universal_robot/CHANGELOG.rst
+++ b/webots_ros2_universal_robot/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package webots_ros2_universal_robot
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2023.1.2 (2024-02-02)
+------------------
+* Add remappings to robot state publisher for ur5e example.
+* Fixed control_config for ur5e moveit example.
+
 2023.1.0 (2023-06-29)
 ------------------
 * Clean simulation reset in launch file.

--- a/webots_ros2_universal_robot/package.xml
+++ b/webots_ros2_universal_robot/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>webots_ros2_universal_robot</name>
-  <version>2023.1.1</version>
+  <version>2023.1.2</version>
   <description>Universal Robot ROS2 interface for Webots.</description>
 
   <maintainer email="support@cyberbotics.com">Cyberbotics</maintainer>

--- a/webots_ros2_universal_robot/setup.py
+++ b/webots_ros2_universal_robot/setup.py
@@ -30,7 +30,7 @@ for (path, _, sub_folder) in os.walk('resource'):
 
 setup(
     name=package_name,
-    version='2023.1.1',
+    version='2023.1.2',
     packages=['webots_ros2_universal_robot'],
     data_files=data_files,
     install_requires=['setuptools', 'launch'],


### PR DESCRIPTION
Once this is merged, I can tag master as `2023.1.2` and bloom a new release into Rolling to unblock the sync.

> Note: There were over 10 commits between the last released version and `master` so hoping there are no new regressions 🤞🏼 