### PR TITLE
set is_urdf_loaded__ of the resource manager to true

### DIFF
--- a/webots_ros2_control/src/Ros2Control.cpp
+++ b/webots_ros2_control/src/Ros2Control.cpp
@@ -99,6 +99,7 @@ namespace webots_ros2_control {
       resourceManager->set_component_state(controlHardware[i].name, active_state);
 #else
       resourceManager->activate_all_components();
+      resourceManager->load_urdf(urdfString, false, false);
 #endif
     }
 


### PR DESCRIPTION
it's probably needed after https://github.com/ros-controls/ros2_control/commit/385293e5d0626c57636a05c66de4380fcfd5bee7

fixes https://github.com/cyberbotics/webots_ros2/issues/893

**Description**
After, https://github.com/ros-controls/ros2_control/commit/385293e5d0626c57636a05c66de4380fcfd5bee7, init_services() won't be called unless is_urdf_loaded__ is set to true. Passing robot description again led to controller name duplicate error.

**Related Issues**
This pull-request fixes issue https://github.com/cyberbotics/webots_ros2/issues/893

**Affected Packages**
List of affected packages:
  - webots_ros2_control

**Tasks**
Add the list of tasks of this PR.
  - [x] Fix ros2_control usage for ros2 humble
