### PR TITLE
Fixed #896 so it works for ROS2 Iron.

### DIFF
--- a/webots_ros2_control/src/Ros2Control.cpp
+++ b/webots_ros2_control/src/Ros2Control.cpp
@@ -99,8 +99,8 @@ namespace webots_ros2_control {
       resourceManager->set_component_state(controlHardware[i].name, active_state);
 #else
       resourceManager->activate_all_components();
-      resourceManager->load_urdf(urdfString, false, false);
 #endif
+      resourceManager->load_urdf(urdfString, false, false);
     }
 
     // Controller Manager


### PR DESCRIPTION
**Description**
Quick bugfix for #896, which doesn't work for `iron` or `rolling` because they use a `ros2_control` hardware interface version  `>3.15`. For some reason still fails for `rolling`. 

**Affected Packages**
List of affected packages:
  - webots_ros2_control
