### PR TITLE
webots_ros2_control:  remove usage of deprecated activate_all_compone…

### DIFF
--- a/webots_ros2_control/src/Ros2Control.cpp
+++ b/webots_ros2_control/src/Ros2Control.cpp
@@ -90,16 +90,10 @@ namespace webots_ros2_control {
       webotsSystem->init(mNode, controlHardware[i]);
       resourceManager->import_component(std::move(webotsSystem), controlHardware[i]);
 
-// Configure and activate all components
-// Necessary hotfix for deprecation of component activation present in "hardware_interface" package for versions above 3.15
-// (#793)
-#if HARDWARE_INTERFACE_VERSION_MAJOR >= 4 || HARDWARE_INTERFACE_VERSION_MAJOR >= 3 && HARDWARE_INTERFACE_VERSION_MINOR >= 15
+      // Configure and activate all components
       using lifecycle_msgs::msg::State;
       rclcpp_lifecycle::State active_state(State::PRIMARY_STATE_ACTIVE, hardware_interface::lifecycle_state_names::ACTIVE);
       resourceManager->set_component_state(controlHardware[i].name, active_state);
-#else
-      resourceManager->activate_all_components();
-#endif
       resourceManager->load_urdf(urdfString, false, false);
     }
 


### PR DESCRIPTION
…nts for humble

https://github.com/ros-controls/ros2_control/pull/1064

**Description**
activate_all_components is deprecated. it'll still work though

**Affected Packages**
List of affected packages:
  - webots_ros2_control
