### PR TITLE
build and pass tests for ros2 rolling

### DIFF
--- a/scripts/ci_after_init.bash
+++ b/scripts/ci_after_init.bash
@@ -43,3 +43,14 @@ fi
 
 # Setup Qt plugins for RViz (can be used once RViz does not randomly crash anymore in GitHub CI).
 #export QT_PLUGIN_PATH=/usr/lib/x86_64-linux-gnu/qt5/plugins
+
+# TODO: Remove once the https://packages.ubuntu.com/noble/python3-flake8 package version is updated.
+# Manually upgrade python3-flake8 to 7.0.0 for noble
+if [[ "${ROS_DISTRO}" == "rolling" ]]; then
+    apt install -y python3-flake8
+    wget http://ftp.ubuntu.com/ubuntu/ubuntu/pool/universe/p/pyflakes/python3-pyflakes_3.2.0-1_all.deb -P /tmp
+    dpkg -i /tmp/python3-pyflakes_3.2.0-1_all.deb
+    wget http://ftp.ubuntu.com/ubuntu/ubuntu/pool/universe/p/python-flake8/python3-flake8_7.0.0-1_all.deb -P /tmp
+    dpkg -i /tmp/python3-flake8_7.0.0-1_all.deb
+    apt --fix-broken install -y
+fi

--- a/webots_ros2_driver/CMakeLists.txt
+++ b/webots_ros2_driver/CMakeLists.txt
@@ -30,7 +30,6 @@ find_package(tinyxml2_vendor REQUIRED)
 find_package(TinyXML2 REQUIRED)
 find_package(yaml-cpp REQUIRED)
 
-# Check which ROS distribution is used, vision_msgs depends of that
 if($ENV{ROS_DISTRO} MATCHES "humble")
   find_package(Python 3.10 EXACT REQUIRED COMPONENTS Development)
 elseif($ENV{ROS_DISTRO} MATCHES "iron")

--- a/webots_ros2_driver/CMakeLists.txt
+++ b/webots_ros2_driver/CMakeLists.txt
@@ -29,7 +29,7 @@ find_package(webots_ros2_msgs REQUIRED)
 find_package(tinyxml2_vendor REQUIRED)
 find_package(TinyXML2 REQUIRED)
 find_package(yaml-cpp REQUIRED)
-find_package(PythonLibs 3.10 EXACT REQUIRED)
+find_package(Python 3.10 EXACT REQUIRED COMPONENTS Development)
 
 add_custom_target(compile-lib-controller ALL
   COMMAND ${CMAKE_COMMAND} -E env "WEBOTS_HOME=${CMAKE_CURRENT_SOURCE_DIR}/webots" make release -f Makefile > /dev/null 2>&1
@@ -54,7 +54,7 @@ include_directories(
   include
   webots/include/controller/c
   webots/include/controller/cpp
-  ${PYTHON_INCLUDE_DIRS}
+  ${Python_INCLUDE_DIRS}
 )
 
 link_directories(${WEBOTS_LIB_BASE})
@@ -117,7 +117,7 @@ add_dependencies(driver
 )
 target_link_libraries(driver
   ${WEBOTS_LIB}
-  ${PYTHON_LIBRARIES}
+  ${Python_LIBRARIES}
   yaml-cpp
 )
 install(

--- a/webots_ros2_driver/CMakeLists.txt
+++ b/webots_ros2_driver/CMakeLists.txt
@@ -29,7 +29,15 @@ find_package(webots_ros2_msgs REQUIRED)
 find_package(tinyxml2_vendor REQUIRED)
 find_package(TinyXML2 REQUIRED)
 find_package(yaml-cpp REQUIRED)
-find_package(Python 3.10 EXACT REQUIRED COMPONENTS Development)
+
+# Check which ROS distribution is used, vision_msgs depends of that
+if($ENV{ROS_DISTRO} MATCHES "humble")
+  find_package(Python 3.10 EXACT REQUIRED COMPONENTS Development)
+elseif($ENV{ROS_DISTRO} MATCHES "iron")
+  find_package(Python 3.10 EXACT REQUIRED COMPONENTS Development)
+elseif($ENV{ROS_DISTRO} MATCHES "rolling")
+  find_package(Python 3.12 EXACT REQUIRED COMPONENTS Development)
+endif()
 
 add_custom_target(compile-lib-controller ALL
   COMMAND ${CMAKE_COMMAND} -E env "WEBOTS_HOME=${CMAKE_CURRENT_SOURCE_DIR}/webots" make release -f Makefile > /dev/null 2>&1


### PR DESCRIPTION
**Description**
Rolling is switched to ubuntu 24

**Affected Packages**
List of affected packages:
  - webots_ros2_driver

**Tasks**
Add the list of tasks of this PR.
  - [x] build for ros2 rolling
  - [x] pass tests on rolling

**Additional context**
With python3.12, missing_whitespace_around_operator is not available in pycodestyle
https://github.com/PyCQA/flake8/commit/9786562feb573d30c73f18e1a0a6685c8584e9b5
