### PR TITLE
webots_ros2_tests: wait for 10 secs before sending nav2 goal

### DIFF
--- a/webots_ros2_tests/test/test_system_turtlebot_tutorial_navigation.py
+++ b/webots_ros2_tests/test/test_system_turtlebot_tutorial_navigation.py
@@ -29,6 +29,7 @@ from ament_index_python.packages import get_package_share_directory
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.actions import IncludeLaunchDescription
 from webots_ros2_tests.utils import TestWebots, initialize_webots_test
+from time import sleep
 
 
 @pytest.mark.rostest
@@ -84,7 +85,7 @@ class TestTurtlebotNavigationTutorial(TestWebots):
         goal_message.pose.pose.orientation.w = 0.928
         goal_action.wait_for_server()
         self.__node.get_logger().info('Server is ready, waiting 10 seconds to send goal position.')
-        self.wait_for_clock(self.__node, messages_to_receive=1000)
+        sleep(10)
         goal_action.send_goal_async(goal_message)
         self.__node.get_logger().info('Goal position sent.')
 


### PR DESCRIPTION
**Description**
the nav2 turtlebot test fails many-a-times.

**Affected Packages**
List of affected packages:
  - webots_ros2_tests

**Tasks**
Add the list of tasks of this PR.
  - [x] check if tests pass more times
