### PR TITLE
update webots release version to 2024a

### DIFF
--- a/scripts/ci_before_init_embed.bash
+++ b/scripts/ci_before_init_embed.bash
@@ -2,7 +2,7 @@
 
 ROS_DISTRO=$1
 
-export WEBOTS_RELEASE_VERSION=2023b-rev1
+export WEBOTS_RELEASE_VERSION=2024a
 export WEBOTS_OFFSCREEN=1
 export CI=1
 export DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
**Description**

Version of the builds is updated from 2023b-rev1 to 2024a