### PR TITLE
Webots now handles initial_value params in position state_interface.

### DIFF
--- a/webots_ros2_control/src/Ros2ControlSystem.cpp
+++ b/webots_ros2_control/src/Ros2ControlSystem.cpp
@@ -62,6 +62,14 @@ namespace webots_ros2_control {
       joint.velocity = NAN;
       joint.acceleration = NAN;
 
+      // Check if state interfaces have initial positions
+      for (hardware_interface::InterfaceInfo stateInterface : component.state_interfaces) {
+        if (stateInterface.name == "position" && !stateInterface.initial_value.empty()) {
+          joint.position = std::stod(stateInterface.initial_value);
+          wb_motor_set_position(joint.motor, std::stod(stateInterface.initial_value));
+        }
+      }
+
       // Configure the command interface
       for (hardware_interface::InterfaceInfo commandInterface : component.command_interfaces) {
         if (commandInterface.name == "position")


### PR DESCRIPTION
**Description**
If the `initial_value` param in the position `state_interface` URDF is set, then the robot joint will move to that position when Webots starts.

**Affected Packages**
List of affected packages:
  - webots_ros2_control

**Additional context**
Currently uses `wb_motor_set_position` which means the robot will start at zero and instantly move once Webots finishes loading. Tried to implement the same behavior using `wb_supervisor_node_set_joint_position` but with no success.