### PR TITLE
Update URDF loading to include default robot configuration in Ros2Control

### DIFF
--- a/webots_ros2_control/src/Ros2Control.cpp
+++ b/webots_ros2_control/src/Ros2Control.cpp
@@ -146,7 +146,15 @@ namespace webots_ros2_control {
       rclcpp_lifecycle::State active_state(State::PRIMARY_STATE_ACTIVE, hardware_interface::lifecycle_state_names::ACTIVE);
       resourceManager->set_component_state(controlHardware[i].name, active_state);
 
-      resourceManager->load_urdf(urdfString, false, false);
+      resourceManager->load_urdf(
+          "<robot name=\"default_robot\">"
+          "  <ros2_control name=\"default_control\" type=\"hardware_interface/DefaultHardware\">"
+          "    <hardware>"
+          "      <plugin>hardware_interface/DefaultPlugin</plugin>"
+          "    </hardware>"
+          "  </ros2_control>"
+          "</robot>",
+          false, false);
     }
 #endif
 


### PR DESCRIPTION
**Description**
For the latest ros2_control update we face 
[webots_controller_SpotArm-6] terminate called after throwing an instance of 'std::runtime_error'
[webots_controller_SpotArm-6]   what():  Hardware name WebotsControl is duplicated. Please provide a unique 'name' in the URDF. for humble

**Affected Packages**
List of affected packages:
  - webots_ros2_control

**Additional context**
load_urdf is called only to set is_urdf_loaded__ = true
