### PR TITLE
Guard condition to check node clock is not zero, to suppress "No clock received" error from ros2_control.

### DIFF
--- a/webots_ros2_control/src/Ros2Control.cpp
+++ b/webots_ros2_control/src/Ros2Control.cpp
@@ -90,7 +90,7 @@ namespace webots_ros2_control {
   void Ros2Control::step() {
     const int nowMs = wb_robot_get_time() * 1000.0;
     const int periodMs = nowMs - mLastControlUpdateMs;
-    if (periodMs >= mControlPeriodMs) {
+    if (periodMs >= mControlPeriodMs && mNode->get_clock()->now() != rclcpp::Time(0, 0, mNode->get_clock()->get_clock_type())) {
       const rclcpp::Duration dt = rclcpp::Duration::from_seconds(mControlPeriodMs / 1000.0);
       mControllerManager->read(mNode->get_clock()->now(), dt);
 

--- a/webots_ros2_driver/CMakeLists.txt
+++ b/webots_ros2_driver/CMakeLists.txt
@@ -32,6 +32,8 @@ find_package(yaml-cpp REQUIRED)
 
 if($ENV{ROS_DISTRO} MATCHES "humble")
   find_package(Python 3.10 EXACT REQUIRED COMPONENTS Development)
+elseif($ENV{ROS_DISTRO} MATCHES "iron")
+  find_package(Python 3.10 EXACT REQUIRED COMPONENTS Development)
 elseif($ENV{ROS_DISTRO} MATCHES "jazzy")
   find_package(Python 3.12 EXACT REQUIRED COMPONENTS Development)
 elseif($ENV{ROS_DISTRO} MATCHES "rolling")


### PR DESCRIPTION
**Description**
This adds a guard condition to `Ros2Control::step()` to check node clock is not zero, fixes the "No clock received" error. Basically stops a step update occurring unless the clock is not zero.

**Affected Packages**
List of affected packages:
  - webots_ros2_control