### PR TITLE
Fix WSL IP detection when DNS Tunnelling is enabled

### DIFF
--- a/webots_ros2_driver/webots_ros2_driver/utils.py
+++ b/webots_ros2_driver/webots_ros2_driver/utils.py
@@ -102,6 +102,8 @@ def get_wsl_ip_address():
                 file.close()
                 if len(tokens[1]) == 0:
                     return '127.0.0.1'
+                if tokens[1] == '10.255.255.254':
+                    return get_host_ip()
                 return tokens[1]
     finally:
         file.close()


### PR DESCRIPTION
**Description**
On a fresh WSL Ubuntu 24.04 installation, ROS2 Jazzy and latests `webots_ros2`. The package fails to connect with the launched Webots instanced.

Upon digging up it turns out the issue is using the wrong IP to connect with the Windows host.

The implementation looks at the ip in `/etc/resolv.conf`, which used to be the Windows host IP, but that's no longer the case when the DNS Tunneling feature is enabled (which is the case by default for new WSL installations).

When DNS Tunneling is enabled, the IP in `/etc/resolv.conf` becomes `10.255.255.254`, which is configured as a lookback address.

The solution I have implemented is to fallback to `get_host_ip` when this IP is found. `get_host_ip` uses `ip route` to get the gateway IP and use it, which is the right one as long as WSL NAT networking mode is used.

This leaves only the case when bot Mirrored networking & NAT Tunneling are enabled together. In such case the package would fail to connect, it should use the IP `127.0.0.1` for it (loopback address).

**Related Issues**
This pull-request fixes issue #1031.

**Affected Packages**
  - webots_ros2_driver

**Tasks**
  - [x] Fix WSL IP detection when DNS Tunnelling is enabled.

**Additional context**
Checkout my [detailed comment] in #1031.
