### PR TITLE
Replace ament_target_dependencies with target_link_libraries

### DIFF
--- a/webots_ros2_control/CMakeLists.txt
+++ b/webots_ros2_control/CMakeLists.txt
@@ -50,14 +50,21 @@ target_include_directories(
   ${PROJECT_NAME}
   PRIVATE
   include
+  ${webots_ros2_driver_INCLUDE_DIRS}
 )
-ament_target_dependencies(
-  ${PROJECT_NAME}
-  hardware_interface
-  controller_manager
-  pluginlib
-  rclcpp
-  webots_ros2_driver
+target_link_libraries(${PROJECT_NAME}
+  PUBLIC
+    hardware_interface::hardware_interface
+    controller_manager::controller_manager
+    pluginlib::pluginlib
+    rclcpp::rclcpp
+    webots_ros2_driver::webots_ros2_driver_imu
+    webots_ros2_driver::webots_ros2_driver_rgbd
+)
+target_link_directories(${PROJECT_NAME}
+  PUBLIC
+    ${CMAKE_INSTALL_PREFIX}/lib/controller
+    ${CMAKE_INSTALL_PREFIX}/../webots_ros2_driver/lib/controller
 )
 
 # Prevent pluginlib from using boost
@@ -74,14 +81,21 @@ target_include_directories(
   ${PROJECT_NAME}_system
   PRIVATE
   include
+  ${webots_ros2_driver_INCLUDE_DIRS}
 )
-ament_target_dependencies(
-  ${PROJECT_NAME}_system
-  hardware_interface
-  pluginlib
-  rclcpp
-  rclcpp_lifecycle
-  webots_ros2_driver
+target_link_libraries(${PROJECT_NAME}_system
+  PUBLIC
+    hardware_interface::hardware_interface
+    pluginlib::pluginlib
+    rclcpp::rclcpp
+    rclcpp_lifecycle::rclcpp_lifecycle
+    webots_ros2_driver::webots_ros2_driver_imu
+    webots_ros2_driver::webots_ros2_driver_rgbd
+)
+target_link_directories(${PROJECT_NAME}_system
+  PUBLIC
+    ${CMAKE_INSTALL_PREFIX}/lib/controller
+    ${CMAKE_INSTALL_PREFIX}/../webots_ros2_driver/lib/controller
 )
 
 # Prevent pluginlib from using boost

--- a/webots_ros2_control/src/Ros2Control.cpp
+++ b/webots_ros2_control/src/Ros2Control.cpp
@@ -48,7 +48,7 @@ namespace webots_ros2_control {
 
     WebotsResourceManager(const WebotsResourceManager &) = delete;
 
-    bool load_and_initialize_components(const std::string &urdf, unsigned int update_rate) override {
+    bool load_and_initialize_components(const std::string &urdf, unsigned int /* update_rate */) override {
       components_are_loaded_and_initialized_ = true;
 
       std::vector<hardware_interface::HardwareInfo> controlHardware;

--- a/webots_ros2_driver/CMakeLists.txt
+++ b/webots_ros2_driver/CMakeLists.txt
@@ -108,26 +108,23 @@ add_executable(driver
   src/utils/Math.cpp
   src/utils/Utils.cpp
 )
-ament_target_dependencies(driver
-  rosgraph_msgs
-  rclcpp
-  pluginlib
-  sensor_msgs
-  std_msgs
-  tf2_geometry_msgs
-  tf2_ros
-  vision_msgs
-  webots_ros2_msgs
-  tinyxml2_vendor
-  TinyXML2
-)
-add_dependencies(driver
-  compile-lib-vehicle
-)
 target_link_libraries(driver
+  ${rosgraph_msgs_TARGETS}
+  rclcpp::rclcpp
+  pluginlib::pluginlib
+  ${sensor_msgs_TARGETS}
+  ${std_msgs_TARGETS}
+  tf2_geometry_msgs::tf2_geometry_msgs
+  tf2_ros::tf2_ros
+  ${vision_msgs_TARGETS}
+  ${webots_ros2_msgs_TARGETS}
+  tinyxml2::tinyxml2
   ${WEBOTS_LIB}
   ${Python_LIBRARIES}
   yaml-cpp
+)
+add_dependencies(driver
+  compile-lib-vehicle
 )
 install(
   DIRECTORY include/
@@ -146,20 +143,19 @@ add_library(
   src/plugins/Ros2SensorPlugin.cpp
   src/utils/Utils.cpp
 )
-ament_target_dependencies(${PROJECT_NAME}_imu
-  rclcpp
-  sensor_msgs
-  webots_ros2_msgs
-  pluginlib
-  tf2_ros
+target_link_libraries(${PROJECT_NAME}_imu
+  rclcpp::rclcpp
+  ${sensor_msgs_TARGETS}
+  ${webots_ros2_msgs_TARGETS}
+  pluginlib::pluginlib
+  tf2_ros::tf2_ros
+  ${WEBOTS_LIB}
 )
 add_dependencies(${PROJECT_NAME}_imu
   compile-lib-vehicle
 )
-target_link_libraries(${PROJECT_NAME}_imu
-  ${WEBOTS_LIB}
-)
 install(TARGETS ${PROJECT_NAME}_imu
+  EXPORT export_${PROJECT_NAME}
   RUNTIME DESTINATION bin
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
@@ -174,19 +170,18 @@ add_library(
   src/plugins/Ros2SensorPlugin.cpp
   src/utils/Utils.cpp
 )
-ament_target_dependencies(${PROJECT_NAME}_rgbd
-  rclcpp
-  sensor_msgs
-  pluginlib
-  tf2_ros
+target_link_libraries(${PROJECT_NAME}_rgbd
+  rclcpp::rclcpp
+  ${sensor_msgs_TARGETS}
+  pluginlib::pluginlib
+  tf2_ros::tf2_ros
+  ${WEBOTS_LIB}
 )
 add_dependencies(${PROJECT_NAME}_rgbd
   compile-lib-vehicle
 )
-target_link_libraries(${PROJECT_NAME}_rgbd
-  ${WEBOTS_LIB}
-)
 install(TARGETS ${PROJECT_NAME}_rgbd
+  EXPORT export_${PROJECT_NAME}
   RUNTIME DESTINATION bin
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
@@ -272,4 +267,8 @@ ament_export_libraries(
   ${PROJECT_NAME}_rgbd
   ${WEBOTS_LIB_PATH}
 )
+
+# Export modern CMake targets
+ament_export_targets(export_${PROJECT_NAME})
+
 ament_package()


### PR DESCRIPTION
`ament_target_dependencies` is deprecated on `kilted` and removed in `rolling`,  It will require a new release on `rolling`.