### PR TITLE
Added hardware_interface ver 5.x.x support

### DIFF
--- a/webots_ros2_control/include/webots_ros2_control/Ros2ControlSystem.hpp
+++ b/webots_ros2_control/include/webots_ros2_control/Ros2ControlSystem.hpp
@@ -54,7 +54,7 @@ namespace webots_ros2_control {
 
     rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_init(
       const hardware_interface::HardwareInfo &info) override;
-#if HARDWARE_INTERFACE_VERSION_MAJOR >= 5 && HARDWARE_INTERFACE_VERSION_MINOR >= 3
+#if HARDWARE_INTERFACE_VERSION_MAJOR > 5 || (HARDWARE_INTERFACE_VERSION_MAJOR == 5 && HARDWARE_INTERFACE_VERSION_MINOR >= 3)
     rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_init(
       const hardware_interface::HardwareComponentInterfaceParams &params) override;
 #endif

--- a/webots_ros2_control/include/webots_ros2_control/Ros2ControlSystem.hpp
+++ b/webots_ros2_control/include/webots_ros2_control/Ros2ControlSystem.hpp
@@ -54,6 +54,10 @@ namespace webots_ros2_control {
 
     rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_init(
       const hardware_interface::HardwareInfo &info) override;
+#if HARDWARE_INTERFACE_VERSION_MAJOR >= 5 && HARDWARE_INTERFACE_VERSION_MINOR >= 3
+    rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_init(
+      const hardware_interface::HardwareComponentInterfaceParams &params) override;
+#endif
     rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_activate(
       const rclcpp_lifecycle::State & /*previous_state*/) override;
     rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_deactivate(

--- a/webots_ros2_control/src/Ros2Control.cpp
+++ b/webots_ros2_control/src/Ros2Control.cpp
@@ -36,7 +36,7 @@ const double CONTROLLER_MANAGER_ALLOWED_SAMPLE_ERROR_MS = 1.0;
 
 namespace webots_ros2_control {
 
-#if HARDWARE_INTERFACE_VERSION_MAJOR >= 5 && HARDWARE_INTERFACE_VERSION_MINOR >= 3
+#if HARDWARE_INTERFACE_VERSION_MAJOR > 5 || (HARDWARE_INTERFACE_VERSION_MAJOR == 5 && HARDWARE_INTERFACE_VERSION_MINOR >= 3)
   class WebotsResourceManager : public hardware_interface::ResourceManager {
   public:
     WebotsResourceManager(webots_ros2_driver::WebotsNode *node) :

--- a/webots_ros2_control/src/Ros2Control.cpp
+++ b/webots_ros2_control/src/Ros2Control.cpp
@@ -36,7 +36,7 @@ const double CONTROLLER_MANAGER_ALLOWED_SAMPLE_ERROR_MS = 1.0;
 
 namespace webots_ros2_control {
 
-#if HARDWARE_INTERFACE_VERSION_MAJOR >= 4 && HARDWARE_INTERFACE_VERSION_MINOR >= 12
+#if HARDWARE_INTERFACE_VERSION_MAJOR >= 5 || HARDWARE_INTERFACE_VERSION_MAJOR >= 4 && HARDWARE_INTERFACE_VERSION_MINOR >= 12
   class WebotsResourceManager : public hardware_interface::ResourceManager {
   public:
     WebotsResourceManager(webots_ros2_driver::WebotsNode *node) :
@@ -118,7 +118,7 @@ namespace webots_ros2_control {
     }
 
     // Control Hardware
-#if HARDWARE_INTERFACE_VERSION_MAJOR >= 4 && HARDWARE_INTERFACE_VERSION_MINOR >= 12
+#if HARDWARE_INTERFACE_VERSION_MAJOR >= 5 || HARDWARE_INTERFACE_VERSION_MAJOR >= 4 && HARDWARE_INTERFACE_VERSION_MINOR >= 12
     std::unique_ptr<hardware_interface::ResourceManager> resourceManager =
       std::make_unique<webots_ros2_control::WebotsResourceManager>(node);
 #else

--- a/webots_ros2_control/src/Ros2Control.cpp
+++ b/webots_ros2_control/src/Ros2Control.cpp
@@ -48,7 +48,7 @@ namespace webots_ros2_control {
 
     WebotsResourceManager(const WebotsResourceManager &) = delete;
 
-    bool load_and_initialize_components(const hardware_interface::ResourceManagerParams & param) override {
+    bool load_and_initialize_components(const hardware_interface::ResourceManagerParams &param) override {
       components_are_loaded_and_initialized_ = true;
 
       std::vector<hardware_interface::HardwareInfo> controlHardware;
@@ -79,6 +79,7 @@ namespace webots_ros2_control {
 
       return components_are_loaded_and_initialized_;
     }
+
   private:
     webots_ros2_driver::WebotsNode *mNode;
     pluginlib::ClassLoader<webots_ros2_control::Ros2ControlSystemInterface> mHardwareLoader;

--- a/webots_ros2_control/src/Ros2Control.cpp
+++ b/webots_ros2_control/src/Ros2Control.cpp
@@ -85,7 +85,7 @@ namespace webots_ros2_control {
     pluginlib::ClassLoader<webots_ros2_control::Ros2ControlSystemInterface> mHardwareLoader;
     rclcpp::Logger mLogger;
   };
-#elif HARDWARE_INTERFACE_VERSION_MAJOR >= 5 || HARDWARE_INTERFACE_VERSION_MAJOR >= 4 && HARDWARE_INTERFACE_VERSION_MINOR >= 12
+#elif HARDWARE_INTERFACE_VERSION_MAJOR == 5 || (HARDWARE_INTERFACE_VERSION_MAJOR == 4 && HARDWARE_INTERFACE_VERSION_MINOR >= 12)
   class WebotsResourceManager : public hardware_interface::ResourceManager {
   public:
     WebotsResourceManager(webots_ros2_driver::WebotsNode *node) :

--- a/webots_ros2_control/src/Ros2Control.cpp
+++ b/webots_ros2_control/src/Ros2Control.cpp
@@ -167,7 +167,7 @@ namespace webots_ros2_control {
     }
 
     // Control Hardware
-#if HARDWARE_INTERFACE_VERSION_MAJOR >= 5 || HARDWARE_INTERFACE_VERSION_MAJOR >= 4 && HARDWARE_INTERFACE_VERSION_MINOR >= 12
+#if HARDWARE_INTERFACE_VERSION_MAJOR > 4 || (HARDWARE_INTERFACE_VERSION_MAJOR == 4 && HARDWARE_INTERFACE_VERSION_MINOR >= 12)
     std::unique_ptr<hardware_interface::ResourceManager> resourceManager =
       std::make_unique<webots_ros2_control::WebotsResourceManager>(node);
 #else

--- a/webots_ros2_control/src/Ros2ControlSystem.cpp
+++ b/webots_ros2_control/src/Ros2ControlSystem.cpp
@@ -98,7 +98,7 @@ namespace webots_ros2_control {
     }
     return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
   }
-#if HARDWARE_INTERFACE_VERSION_MAJOR >= 5 && HARDWARE_INTERFACE_VERSION_MINOR >= 3
+#if HARDWARE_INTERFACE_VERSION_MAJOR > 5 || (HARDWARE_INTERFACE_VERSION_MAJOR == 5 && HARDWARE_INTERFACE_VERSION_MINOR >= 3)
   rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn Ros2ControlSystem::on_init(
     const hardware_interface::HardwareComponentInterfaceParams &params) {
     if (hardware_interface::SystemInterface::on_init(params) !=

--- a/webots_ros2_control/src/Ros2ControlSystem.cpp
+++ b/webots_ros2_control/src/Ros2ControlSystem.cpp
@@ -98,6 +98,16 @@ namespace webots_ros2_control {
     }
     return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
   }
+#if HARDWARE_INTERFACE_VERSION_MAJOR >= 5 && HARDWARE_INTERFACE_VERSION_MINOR >= 3
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn Ros2ControlSystem::on_init(
+    const hardware_interface::HardwareComponentInterfaceParams &params) {
+    if (hardware_interface::SystemInterface::on_init(params) !=
+        rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS) {
+      return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR;
+    }
+    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+  }
+#endif
 
   std::vector<hardware_interface::StateInterface> Ros2ControlSystem::export_state_interfaces() {
     std::vector<hardware_interface::StateInterface> interfaces;


### PR DESCRIPTION
Signed-off-by: soham2560

**Description**
There is a Build Error for webots_ros2_control on Rolling as described in #1041. Seems to be from the recent update to 5.0.0 and above for versions (refer https://github.com/ros-controls/ros2_control/commit/151b22ee7bbc9056cfd7df1a935b024e60b5b687)

After some thought, have decided to also add support for ver5.3 here, as it introduces updated API.
- refer [added ver5.3 support](https://github.com/cyberbotics/webots_ros2/pull/1042/commits/5301dd9f1e349c7eda5bed1516bd617c644a3d85) for changes made

**Related Issues**
This pull-request fixes issue #1041

**Affected Packages**
List of affected packages:
  - webots_ros2_control
